### PR TITLE
feat: add hot reload with --watch flag for config updtes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/pkg/engine/configmanager/manager.go
+++ b/pkg/engine/configmanager/manager.go
@@ -1,0 +1,225 @@
+package configmanager
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/Servflow/servflow/internal/logging"
+	"github.com/Servflow/servflow/pkg/definitions"
+	"github.com/Servflow/servflow/pkg/engine/yamlloader"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// HandlerCreator is an interface for creating HTTP handlers from API configs
+type HandlerCreator interface {
+	CreateHandler(*apiconfig.APIConfig) (http.Handler, error)
+}
+
+// ConfigManager manages API configurations and their handlers with thread-safe updates
+type ConfigManager struct {
+	sync.RWMutex
+	handlers     map[string]http.Handler // configID → handler
+	fileToConfig map[string]string       // filepath → configID
+	configs      map[string]*apiconfig.APIConfig
+	yamlLoader   *yamlloader.YAMLLoader
+	creator      HandlerCreator
+}
+
+// New creates a new ConfigManager
+func New(yamlLoader *yamlloader.YAMLLoader, creator HandlerCreator) *ConfigManager {
+	return &ConfigManager{
+		handlers:     make(map[string]http.Handler),
+		fileToConfig: make(map[string]string),
+		configs:      make(map[string]*apiconfig.APIConfig),
+		yamlLoader:   yamlLoader,
+		creator:      creator,
+	}
+}
+
+// LoadAllConfigs loads all configs from a folder
+func (cm *ConfigManager) LoadAllConfigs(configFolder string) ([]*apiconfig.APIConfig, error) {
+	logger := logging.GetLogger()
+	logger.Info("Loading all configs from folder", zap.String("folder", configFolder))
+
+	configs, err := cm.yamlLoader.FetchAPIConfigs(false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch API configs: %w", err)
+	}
+
+	cm.Lock()
+	defer cm.Unlock()
+
+	for _, config := range configs {
+		handler, err := cm.creator.CreateHandler(config)
+		if err != nil {
+			logger.Error("Failed to create handler for config",
+				zap.String("configID", config.ID),
+				zap.Error(err))
+			continue
+		}
+
+		cm.handlers[config.ID] = handler
+		cm.configs[config.ID] = config
+		logger.Info("Loaded config", zap.String("configID", config.ID))
+	}
+
+	return configs, nil
+}
+
+// LoadConfig loads a single config file
+func (cm *ConfigManager) LoadConfig(filePath string) error {
+	logger := logging.GetLogger()
+	logger.Info("Loading config from file", zap.String("file", filePath))
+
+	config, err := cm.loadAndValidateConfig(filePath)
+	if err != nil {
+		logger.Error("Failed to load config", zap.String("file", filePath), zap.Error(err))
+		return err
+	}
+
+	handler, err := cm.creator.CreateHandler(config)
+	if err != nil {
+		logger.Error("Failed to create handler", zap.String("configID", config.ID), zap.Error(err))
+		return err
+	}
+
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.handlers[config.ID] = handler
+	cm.configs[config.ID] = config
+	cm.fileToConfig[filePath] = config.ID
+
+	logger.Info("Config loaded successfully", zap.String("configID", config.ID), zap.String("file", filePath))
+	return nil
+}
+
+// ReloadConfig reloads a specific config file
+func (cm *ConfigManager) ReloadConfig(filePath string) error {
+	logger := logging.GetLogger()
+	logger.Info("Reloading config from file", zap.String("file", filePath))
+
+	config, err := cm.loadAndValidateConfig(filePath)
+	if err != nil {
+		logger.Error("Failed to reload config, keeping previous version",
+			zap.String("file", filePath),
+			zap.Error(err))
+		return err
+	}
+
+	handler, err := cm.creator.CreateHandler(config)
+	if err != nil {
+		logger.Error("Failed to create handler, keeping previous version",
+			zap.String("configID", config.ID),
+			zap.Error(err))
+		return err
+	}
+
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.handlers[config.ID] = handler
+	cm.configs[config.ID] = config
+	cm.fileToConfig[filePath] = config.ID
+
+	logger.Info("Config reloaded successfully", zap.String("configID", config.ID), zap.String("file", filePath))
+	return nil
+}
+
+// RemoveConfig removes a config
+func (cm *ConfigManager) RemoveConfig(filePath string) error {
+	logger := logging.GetLogger()
+
+	cm.Lock()
+	defer cm.Unlock()
+
+	configID, ok := cm.fileToConfig[filePath]
+	if !ok {
+		logger.Warn("Config file not tracked", zap.String("file", filePath))
+		return nil
+	}
+
+	delete(cm.handlers, configID)
+	delete(cm.configs, configID)
+	delete(cm.fileToConfig, filePath)
+
+	logger.Info("Config removed", zap.String("configID", configID), zap.String("file", filePath))
+	return nil
+}
+
+// GetHandler retrieves a handler by config ID (thread-safe)
+func (cm *ConfigManager) GetHandler(configID string) http.Handler {
+	cm.RLock()
+	defer cm.RUnlock()
+	return cm.handlers[configID]
+}
+
+// GetConfig retrieves a config by ID (thread-safe)
+func (cm *ConfigManager) GetConfig(configID string) *apiconfig.APIConfig {
+	cm.RLock()
+	defer cm.RUnlock()
+	return cm.configs[configID]
+}
+
+// ReloadAllConfigs reloads all currently loaded configs
+func (cm *ConfigManager) ReloadAllConfigs() error {
+	logger := logging.GetLogger()
+	logger.Info("Reloading all configs")
+
+	cm.RLock()
+	files := make([]string, 0, len(cm.fileToConfig))
+	for file := range cm.fileToConfig {
+		files = append(files, file)
+	}
+	cm.RUnlock()
+
+	var errors []error
+	for _, file := range files {
+		if err := cm.ReloadConfig(file); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		logger.Error("Some configs failed to reload", zap.Int("count", len(errors)))
+		return fmt.Errorf("%d config(s) failed to reload", len(errors))
+	}
+
+	logger.Info("All configs reloaded successfully")
+	return nil
+}
+
+// RegisterFile registers a file path to config ID mapping
+func (cm *ConfigManager) RegisterFile(filePath string, configID string) {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.fileToConfig[filePath] = configID
+}
+
+// loadAndValidateConfig loads and validates a single config file
+func (cm *ConfigManager) loadAndValidateConfig(filePath string) (*apiconfig.APIConfig, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var config apiconfig.APIConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	return &config, nil
+}

--- a/pkg/engine/configmanager/manager.go
+++ b/pkg/engine/configmanager/manager.go
@@ -223,3 +223,15 @@ func (cm *ConfigManager) loadAndValidateConfig(filePath string) (*apiconfig.APIC
 
 	return &config, nil
 }
+
+// RegisterHandlerForTest registers a handler for testing purposes
+// This is a test helper method that should only be used in tests
+func (cm *ConfigManager) RegisterHandlerForTest(configID string, handler http.Handler, config *apiconfig.APIConfig) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.handlers[configID] = handler
+	if config != nil {
+		cm.configs[configID] = config
+	}
+}

--- a/pkg/engine/server/engine.go
+++ b/pkg/engine/server/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Servflow/servflow/config"
 	"github.com/Servflow/servflow/internal/logging"
 	"github.com/Servflow/servflow/internal/storage"
+	apiconfig "github.com/Servflow/servflow/pkg/definitions"
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/agent"
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/authenticate"
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/delete_action"

--- a/pkg/engine/server/engine.go
+++ b/pkg/engine/server/engine.go
@@ -31,22 +31,26 @@ import (
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/storevector"
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/stub"
 	_ "github.com/Servflow/servflow/pkg/engine/actions/executables/update"
+	"github.com/Servflow/servflow/pkg/engine/configmanager"
 	"github.com/Servflow/servflow/pkg/engine/integration"
 	_ "github.com/Servflow/servflow/pkg/engine/integration/integrations/mongo"
 	_ "github.com/Servflow/servflow/pkg/engine/integration/integrations/openai"
 	_ "github.com/Servflow/servflow/pkg/engine/integration/integrations/qdrant"
 	_ "github.com/Servflow/servflow/pkg/engine/integration/integrations/sql"
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/Servflow/servflow/pkg/engine/watcher"
 	"github.com/Servflow/servflow/pkg/engine/yamlloader"
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 )
 
 type Engine struct {
-	server     *http.Server
-	cfg        *config.Config
-	yamlLoader *yamlloader.YAMLLoader
-	mcpServer  *server.MCPServer
+	server        *http.Server
+	cfg           *config.Config
+	yamlLoader    *yamlloader.YAMLLoader
+	mcpServer     *server.MCPServer
+	configManager *configmanager.ConfigManager
+	watcher       *watcher.Watcher
 
 	ctx    context.Context
 	cancel func()
@@ -67,7 +71,7 @@ func (e *Engine) DoneChan() <-chan struct{} {
 	return e.ctx.Done()
 }
 
-func (e *Engine) Start() error {
+func (e *Engine) Start(enableWatch bool) error {
 	yamlLoader := yamlloader.NewYAMLLoader(
 		e.cfg.ConfigFolder,
 		e.cfg.IntegrationsFile,
@@ -76,9 +80,13 @@ func (e *Engine) Start() error {
 	e.yamlLoader = yamlLoader
 	requestctx.SetSecretStore(yamlLoader)
 
-	apiConfigs, err := yamlLoader.FetchAPIConfigs(false)
+	// Create ConfigManager
+	e.configManager = configmanager.New(yamlLoader, e)
+
+	// Load all configs via ConfigManager
+	apiConfigs, err := e.configManager.LoadAllConfigs(e.cfg.ConfigFolder)
 	if err != nil {
-		return fmt.Errorf("error fetching actions: %w", err)
+		return fmt.Errorf("error loading configs: %w", err)
 	}
 
 	datasourcesConfig, err := yamlLoader.FetchIntegrationsConfig()
@@ -96,6 +104,17 @@ func (e *Engine) Start() error {
 		return fmt.Errorf("error creating server: %w", err)
 	}
 	e.server = srv
+
+	// Start file watcher if enabled
+	if enableWatch {
+		w, err := watcher.New(e.configManager, e.cfg.ConfigFolder)
+		if err != nil {
+			return fmt.Errorf("error creating file watcher: %w", err)
+		}
+		e.watcher = w
+		e.watcher.Start()
+		logging.Info(e.ctx, "File watcher enabled - configs will hot reload on changes")
+	}
 
 	logging.Info(e.ctx, "starting engine...")
 	e.startServer()
@@ -207,6 +226,12 @@ func (e *Engine) startServer() {
 }
 
 func (e *Engine) Stop() error {
+	if e.watcher != nil {
+		if err := e.watcher.Stop(); err != nil {
+			logging.Error(e.ctx, "error stopping file watcher", err)
+		}
+	}
+
 	cl, err := storage.GetClient()
 	if err != nil {
 		return err
@@ -216,4 +241,15 @@ func (e *Engine) Stop() error {
 		return err
 	}
 	return e.server.Shutdown(e.ctx)
+}
+
+func (e *Engine) Reload() error {
+	if e.configManager == nil {
+		return fmt.Errorf("config manager not initialized")
+	}
+	return e.configManager.ReloadAllConfigs()
+}
+
+func (e *Engine) CreateHandler(config *apiconfig.APIConfig) (http.Handler, error) {
+	return e.createBasicHandler(config)
 }

--- a/pkg/engine/server/server.go
+++ b/pkg/engine/server/server.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/Servflow/servflow/internal/logging"
+	"github.com/Servflow/servflow/pkg/definitions"
+	"github.com/Servflow/servflow/pkg/engine/configmanager"
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/gorilla/mux"
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
-
-	"github.com/Servflow/servflow/pkg/definitions"
-	"github.com/gorilla/mux"
 )
 
 // TODO move stuff and test engine easily
@@ -64,13 +64,14 @@ func (e *Engine) createCustomMuxHandler(configs []*apiconfig.APIConfig) http.Han
 			continue
 		}
 
-		handler, err := e.createBasicHandler(conf)
-		if err != nil {
-			logger.Error("Error creating APIHandler", zap.Error(err), zap.String("api", conf.ID), zap.String("path", listenPath))
-			continue
+		// Create proxy handler instead of direct handler
+		// This allows hot reloading by looking up the current handler dynamically
+		proxyHandler := &ProxyHandler{
+			configID: conf.ID,
+			manager:  e.configManager,
 		}
 
-		h := wrapMiddleware(handler)
+		h := wrapMiddleware(proxyHandler)
 		logger.Info("registered handler for " + conf.ID)
 
 		r.Handle(listenPath, h).Methods(method, http.MethodOptions)
@@ -82,6 +83,23 @@ func (e *Engine) createCustomMuxHandler(configs []*apiconfig.APIConfig) http.Han
 	}
 
 	return r
+}
+
+
+type ProxyHandler struct {
+	configID string
+	manager  *configmanager.ConfigManager
+}
+
+func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	handler := p.manager.GetHandler(p.configID)
+	if handler == nil {
+		logging.GetLogger().Error("Handler not found for config", zap.String("configID", p.configID))
+		http.Error(w, "Handler not found", http.StatusNotFound)
+		return
+	}
+
+	handler.ServeHTTP(w, r)
 }
 
 func wrapMiddleware(handler http.Handler) http.Handler {

--- a/pkg/engine/server/server_test.go
+++ b/pkg/engine/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	apiconfig "github.com/Servflow/servflow/pkg/definitions"
+	"github.com/Servflow/servflow/pkg/engine/configmanager"
 	plan2 "github.com/Servflow/servflow/pkg/engine/plan"
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,22 @@ func (r *TestRunner) WithDefaultMocks() *TestRunner {
 // Init initializes the test runner, creating the HTTP handler
 func (r *TestRunner) Init() *TestRunner {
 	eng := Engine{}
+
+	// Create a config manager with the engine as the handler creator
+	configManager := configmanager.New(nil, &eng)
+
+	// Set the config manager on the engine before creating handlers
+	eng.configManager = configManager
+
+	// Create the handler for the test config
+	handler, err := eng.createBasicHandler(r.apiConfig)
+	if err != nil {
+		r.t.Fatalf("failed to create handler: %v", err)
+	}
+
+	// Register the handler in the config manager for testing
+	configManager.RegisterHandlerForTest(r.apiConfig.ID, handler, r.apiConfig)
+
 	r.handler = eng.createCustomMuxHandler([]*apiconfig.APIConfig{r.apiConfig})
 	return r
 }

--- a/pkg/engine/watcher/watcher.go
+++ b/pkg/engine/watcher/watcher.go
@@ -1,0 +1,196 @@
+package watcher
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Servflow/servflow/internal/logging"
+	"github.com/fsnotify/fsnotify"
+	"go.uber.org/zap"
+)
+
+// ConfigReloader is an interface for reloading configs
+type ConfigReloader interface {
+	ReloadConfig(filePath string) error
+	LoadConfig(filePath string) error
+	RemoveConfig(filePath string) error
+}
+
+// Watcher watches for file system changes and triggers config reloads
+type Watcher struct {
+	fsWatcher      *fsnotify.Watcher
+	configReloader ConfigReloader
+	configFolder   string
+	debounceTimers map[string]*time.Timer
+	timerMutex     sync.Mutex
+	ctx            context.Context
+	cancel         context.CancelFunc
+	debouncePeriod time.Duration
+}
+
+func New(configReloader ConfigReloader, configFolder string) (*Watcher, error) {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w := &Watcher{
+		fsWatcher:      fsWatcher,
+		configReloader: configReloader,
+		configFolder:   configFolder,
+		debounceTimers: make(map[string]*time.Timer),
+		ctx:            ctx,
+		cancel:         cancel,
+		debouncePeriod: 300 * time.Millisecond,
+	}
+
+	if err := fsWatcher.Add(configFolder); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	logging.GetLogger().Info("Watching:", zap.String("folder", configFolder))
+	return w, nil
+}
+
+func (w *Watcher) Start() {
+	logger := logging.GetLogger()
+	logger.Info("Starting file watcher")
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-w.fsWatcher.Events:
+				if !ok {
+					return
+				}
+				w.handleEvent(event)
+
+			case err, ok := <-w.fsWatcher.Errors:
+				if !ok {
+					return
+				}
+				logger.Error("File watcher error", zap.Error(err))
+
+			case <-w.ctx.Done():
+				logger.Info("File watcher stopped")
+				return
+			}
+		}
+	}()
+}
+
+func (w *Watcher) Stop() error {
+	logger := logging.GetLogger()
+	logger.Info("Stopping file watcher")
+
+	w.cancel()
+
+	w.timerMutex.Lock()
+	for _, timer := range w.debounceTimers {
+		timer.Stop()
+	}
+	w.timerMutex.Unlock()
+
+	return w.fsWatcher.Close()
+}
+
+func (w *Watcher) handleEvent(event fsnotify.Event) {
+	logger := logging.GetLogger()
+
+	// Only process YAML files
+	if !isYAMLFile(event.Name) {
+		return
+	}
+
+	logger.Debug("File event detected",
+		zap.String("file", event.Name),
+		zap.String("op", event.Op.String()))
+
+	switch {
+	case event.Op&fsnotify.Write == fsnotify.Write:
+		w.debounceReload(event.Name)
+
+	case event.Op&fsnotify.Create == fsnotify.Create:
+		w.debounceLoad(event.Name)
+
+	case event.Op&fsnotify.Remove == fsnotify.Remove:
+		w.handleRemove(event.Name)
+
+	case event.Op&fsnotify.Rename == fsnotify.Rename:
+		w.handleRemove(event.Name)
+	}
+}
+
+// debounceReload debounces reload events to avoid multiple reloads
+func (w *Watcher) debounceReload(filePath string) {
+	logger := logging.GetLogger()
+
+	w.timerMutex.Lock()
+	defer w.timerMutex.Unlock()
+
+	// If timer exists, reset it
+	if timer, exists := w.debounceTimers[filePath]; exists {
+		timer.Stop()
+	}
+
+	// Create new timer
+	w.debounceTimers[filePath] = time.AfterFunc(w.debouncePeriod, func() {
+		logger.Info("Config file changed, reloading", zap.String("file", filePath))
+		if err := w.configReloader.ReloadConfig(filePath); err != nil {
+			logger.Error("Failed to reload config", zap.String("file", filePath), zap.Error(err))
+		}
+
+		// Remove timer after execution
+		w.timerMutex.Lock()
+		delete(w.debounceTimers, filePath)
+		w.timerMutex.Unlock()
+	})
+}
+
+// debounceLoad debounces load events for new files
+func (w *Watcher) debounceLoad(filePath string) {
+	logger := logging.GetLogger()
+
+	w.timerMutex.Lock()
+	defer w.timerMutex.Unlock()
+
+	// If timer exists, reset it
+	if timer, exists := w.debounceTimers[filePath]; exists {
+		timer.Stop()
+	}
+
+	// Create new timer
+	w.debounceTimers[filePath] = time.AfterFunc(w.debouncePeriod, func() {
+		logger.Info("New config file created, loading", zap.String("file", filePath))
+		if err := w.configReloader.LoadConfig(filePath); err != nil {
+			logger.Error("Failed to load config", zap.String("file", filePath), zap.Error(err))
+		}
+
+		// Remove timer after execution
+		w.timerMutex.Lock()
+		delete(w.debounceTimers, filePath)
+		w.timerMutex.Unlock()
+	})
+}
+
+// handleRemove handles file removal
+func (w *Watcher) handleRemove(filePath string) {
+	logger := logging.GetLogger()
+	logger.Info("Config file removed", zap.String("file", filePath))
+
+	if err := w.configReloader.RemoveConfig(filePath); err != nil {
+		logger.Error("Failed to remove config", zap.String("file", filePath), zap.Error(err))
+	}
+}
+
+// isYAMLFile checks if a file is a YAML file
+func isYAMLFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/pkg/engine/watcher/watcher.go
+++ b/pkg/engine/watcher/watcher.go
@@ -1,0 +1,202 @@
+package watcher
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Servflow/servflow/internal/logging"
+	"github.com/fsnotify/fsnotify"
+	"go.uber.org/zap"
+)
+
+// ConfigReloader is an interface for reloading configs
+type ConfigReloader interface {
+	ReloadConfig(filePath string) error
+	LoadConfig(filePath string) error
+	RemoveConfig(filePath string) error
+}
+
+// Watcher watches for file system changes and triggers config reloads
+type Watcher struct {
+	fsWatcher      *fsnotify.Watcher
+	configReloader ConfigReloader
+	configFolder   string
+	debounceTimers map[string]*time.Timer
+	timerMutex     sync.Mutex
+	ctx            context.Context
+	cancel         context.CancelFunc
+	debouncePeriod time.Duration
+}
+
+
+func New(configReloader ConfigReloader, configFolder string) (*Watcher, error) {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w := &Watcher{
+		fsWatcher:      fsWatcher,
+		configReloader: configReloader,
+		configFolder:   configFolder,
+		debounceTimers: make(map[string]*time.Timer),
+		ctx:            ctx,
+		cancel:         cancel,
+		debouncePeriod: 300 * time.Millisecond,
+	}
+
+
+	if err := fsWatcher.Add(configFolder); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	logging.GetLogger().Info("Watching:", zap.String("folder", configFolder))
+	return w, nil
+}
+
+
+func (w *Watcher) Start() {
+	logger := logging.GetLogger()
+	logger.Info("Starting file watcher")
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-w.fsWatcher.Events:
+				if !ok {
+					return
+				}
+				w.handleEvent(event)
+
+			case err, ok := <-w.fsWatcher.Errors:
+				if !ok {
+					return
+				}
+				logger.Error("File watcher error", zap.Error(err))
+
+			case <-w.ctx.Done():
+				logger.Info("File watcher stopped")
+				return
+			}
+		}
+	}()
+}
+
+
+func (w *Watcher) Stop() error {
+	logger := logging.GetLogger()
+	logger.Info("Stopping file watcher")
+
+	w.cancel()
+
+
+	w.timerMutex.Lock()
+	for _, timer := range w.debounceTimers {
+		timer.Stop()
+	}
+	w.timerMutex.Unlock()
+
+	return w.fsWatcher.Close()
+}
+
+
+func (w *Watcher) handleEvent(event fsnotify.Event) {
+	logger := logging.GetLogger()
+
+	// Only process YAML files
+	if !isYAMLFile(event.Name) {
+		return
+	}
+
+	logger.Debug("File event detected",
+		zap.String("file", event.Name),
+		zap.String("op", event.Op.String()))
+
+	switch {
+	case event.Op&fsnotify.Write == fsnotify.Write:
+		w.debounceReload(event.Name)
+
+	case event.Op&fsnotify.Create == fsnotify.Create:
+		w.debounceLoad(event.Name)
+
+	case event.Op&fsnotify.Remove == fsnotify.Remove:
+		w.handleRemove(event.Name)
+
+	case event.Op&fsnotify.Rename == fsnotify.Rename:
+		w.handleRemove(event.Name)
+	}
+}
+
+// debounceReload debounces reload events to avoid multiple reloads
+func (w *Watcher) debounceReload(filePath string) {
+	logger := logging.GetLogger()
+
+	w.timerMutex.Lock()
+	defer w.timerMutex.Unlock()
+
+	// If timer exists, reset it
+	if timer, exists := w.debounceTimers[filePath]; exists {
+		timer.Stop()
+	}
+
+	// Create new timer
+	w.debounceTimers[filePath] = time.AfterFunc(w.debouncePeriod, func() {
+		logger.Info("Config file changed, reloading", zap.String("file", filePath))
+		if err := w.configReloader.ReloadConfig(filePath); err != nil {
+			logger.Error("Failed to reload config", zap.String("file", filePath), zap.Error(err))
+		}
+
+		// Remove timer after execution
+		w.timerMutex.Lock()
+		delete(w.debounceTimers, filePath)
+		w.timerMutex.Unlock()
+	})
+}
+
+// debounceLoad debounces load events for new files
+func (w *Watcher) debounceLoad(filePath string) {
+	logger := logging.GetLogger()
+
+	w.timerMutex.Lock()
+	defer w.timerMutex.Unlock()
+
+	// If timer exists, reset it
+	if timer, exists := w.debounceTimers[filePath]; exists {
+		timer.Stop()
+	}
+
+	// Create new timer
+	w.debounceTimers[filePath] = time.AfterFunc(w.debouncePeriod, func() {
+		logger.Info("New config file created, loading", zap.String("file", filePath))
+		if err := w.configReloader.LoadConfig(filePath); err != nil {
+			logger.Error("Failed to load config", zap.String("file", filePath), zap.Error(err))
+		}
+
+		// Remove timer after execution
+		w.timerMutex.Lock()
+		delete(w.debounceTimers, filePath)
+		w.timerMutex.Unlock()
+	})
+}
+
+// handleRemove handles file removal
+func (w *Watcher) handleRemove(filePath string) {
+	logger := logging.GetLogger()
+	logger.Info("Config file removed", zap.String("file", filePath))
+
+	if err := w.configReloader.RemoveConfig(filePath); err != nil {
+		logger.Error("Failed to remove config", zap.String("file", filePath), zap.Error(err))
+	}
+}
+
+// isYAMLFile checks if a file is a YAML file
+func isYAMLFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".yaml" || ext == ".yml"
+}


### PR DESCRIPTION
Add configuration hot reload using fsnotify file watching. Configs can now
be updated without server restart when using --watch flag.

- Add ConfigManager with thread-safe handler management (RWMutex)
- Add Watcher with 300ms debouncing for file change detection  
- Implement ProxyHandler pattern for dynamic handler lookup
- Add --watch flag to start command
- Add SIGHUP signal handler for manual reload

Usage: servflow start --watch --integrations integrations.yaml configs/