### PR TITLE
requestctx: own request lifecycle; defer root span end to true total

### DIFF
--- a/pkg/agent/tools/tools_test.go
+++ b/pkg/agent/tools/tools_test.go
@@ -313,7 +313,7 @@ func TestNewClient(t *testing.T) {
 			Description: "Test workflow execution",
 			Params:      []string{"param1", "param2"},
 			ReturnValue: `{{ printf "%s%s" .variable_actions_workflow_action.result (tool_param "param1") }}`,
-			Start:       requestctx2.ActionConfigPrefix + "workflow_action",
+			Start:       apiconfig.ActionConfigPrefix + "workflow_action",
 		}))
 		require.NoError(t, err)
 		require.NotNil(t, manager)
@@ -408,7 +408,7 @@ func TestNewClient(t *testing.T) {
 				Type:       apiconfig.FileInputTypeAction,
 				Identifier: "file_action",
 			},
-			Start: requestctx2.ActionConfigPrefix + "file_action",
+			Start: apiconfig.ActionConfigPrefix + "file_action",
 		}))
 		require.NoError(t, err)
 		require.NotNil(t, manager)
@@ -434,7 +434,7 @@ func TestNewClient(t *testing.T) {
 			Description: "Test invalid type",
 			Params:      []string{"param1"},
 			Type:        "invalid",
-			Start:       requestctx2.ActionConfigPrefix + "some_action",
+			Start:       apiconfig.ActionConfigPrefix + "some_action",
 		}))
 		assert.ErrorContains(t, err, "invalid workflow tool type: invalid")
 	})

--- a/pkg/engine/actions/executables/http/http_test.go
+++ b/pkg/engine/actions/executables/http/http_test.go
@@ -393,7 +393,7 @@ func TestHTTPActionWithEscapeTemplateViaPlanExecute(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute the plan
-	_, err = p.Execute(ctx, requestctx.ActionConfigPrefix+"test_http")
+	_, err = p.Execute(ctx, apiconfig.ActionConfigPrefix+"test_http")
 	require.NoError(t, err)
 
 	// Verify the server was called
@@ -468,7 +468,7 @@ func TestHTTPActionObjectBodyViaPlanExecute(t *testing.T) {
 	}, "")
 	require.NoError(t, err)
 
-	_, err = p.Execute(ctx, requestctx.ActionConfigPrefix+"test_http")
+	_, err = p.Execute(ctx, apiconfig.ActionConfigPrefix+"test_http")
 	require.NoError(t, err)
 
 	require.True(t, serverCalled, "Test server should have been called")

--- a/pkg/engine/actions/executables/parallel/parallel_test.go
+++ b/pkg/engine/actions/executables/parallel/parallel_test.go
@@ -81,9 +81,9 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
-					requestctx.ActionConfigPrefix + "action2",
-					requestctx.ActionConfigPrefix + "action3",
+					apiconfig.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action2",
+					apiconfig.ActionConfigPrefix + "action3",
 				},
 				StopOnFailure: true,
 			},
@@ -125,9 +125,9 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
-					requestctx.ActionConfigPrefix + "action2",
-					requestctx.ActionConfigPrefix + "action3",
+					apiconfig.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action2",
+					apiconfig.ActionConfigPrefix + "action3",
 				},
 				StopOnFailure: true,
 			},
@@ -171,9 +171,9 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
-					requestctx.ActionConfigPrefix + "action2",
-					requestctx.ActionConfigPrefix + "action3",
+					apiconfig.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action2",
+					apiconfig.ActionConfigPrefix + "action3",
 				},
 				StopOnFailure: false,
 			},
@@ -230,9 +230,9 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
-					requestctx.ActionConfigPrefix + "action2",
-					requestctx.ActionConfigPrefix + "action3",
+					apiconfig.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action2",
+					apiconfig.ActionConfigPrefix + "action3",
 				},
 				StopOnFailure: true,
 			},
@@ -278,9 +278,9 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
-					requestctx.ActionConfigPrefix + "action2",
-					requestctx.ActionConfigPrefix + "action3",
+					apiconfig.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action2",
+					apiconfig.ActionConfigPrefix + "action3",
 				},
 				StopOnFailure: false,
 			},
@@ -325,7 +325,7 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action1",
 				},
 				StopOnFailure: true,
 			},
@@ -375,7 +375,7 @@ func TestParallelExec_Execute(t *testing.T) {
 		parallelExec := &Exec{
 			config: Config{
 				Steps: []string{
-					requestctx.ActionConfigPrefix + "action1",
+					apiconfig.ActionConfigPrefix + "action1",
 				},
 				StopOnFailure: true,
 			},

--- a/pkg/engine/plan/action.go
+++ b/pkg/engine/plan/action.go
@@ -189,7 +189,9 @@ func (a *Action) dispatchBackgroundChains(ctx context.Context, logger *zap.Logge
 
 		logger.Debug("dispatching background chain", zap.String("dispatch_id", dispatchID))
 
+		endFlow := reqCtx.BeginFlow("dispatch:" + dispatchID)
 		bgMgr.Dispatch(func(bgCtx context.Context) {
+			defer endFlow() // FIRST: a panic or early return must still end the flow
 			// Detach the request context's cancellation so the chain survives the
 			// HTTP request completing, while retaining its values — crucially the
 			// live, recording OTEL span. Re-injecting only a remote span context

--- a/pkg/engine/plan/action_test.go
+++ b/pkg/engine/plan/action_test.go
@@ -65,7 +65,7 @@ func TestAction_Execute(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-			field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .test }}")
+			field, err := requestctx.ExecuteTemplateString(ctx, "{{ .test }}")
 			require.NoError(t, err)
 			assert.Equal(t, "response string", field)
 		})
@@ -102,7 +102,7 @@ func TestAction_Execute(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-			field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .test }}")
+			field, err := requestctx.ExecuteTemplateString(ctx, "{{ .test }}")
 			require.NoError(t, err)
 			assert.Equal(t, "response string", field)
 		})
@@ -132,7 +132,7 @@ func TestAction_Execute(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-			field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .custom_out }}")
+			field, err := requestctx.ExecuteTemplateString(ctx, "{{ .custom_out }}")
 			require.NoError(t, err)
 			assert.Equal(t, "custom response", field)
 		})
@@ -295,7 +295,7 @@ func TestAction_ExecuteWithReplica(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-		field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .test }}")
+		field, err := requestctx.ExecuteTemplateString(ctx, "{{ .test }}")
 		require.NoError(t, err)
 		assert.Equal(t, "replica response", field)
 	})
@@ -329,7 +329,7 @@ func TestAction_ExecuteWithReplica(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-		field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .test }}")
+		field, err := requestctx.ExecuteTemplateString(ctx, "{{ .test }}")
 		require.NoError(t, err)
 		assert.Equal(t, "direct response", field)
 	})
@@ -364,7 +364,7 @@ func TestAction_ExecuteWithReplica(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &stepWrapper{id: "next", step: &nextStep}, next)
 
-		field, err := requestctx.ReplaceVariableValuesInContext(ctx, "{{ .test }}")
+		field, err := requestctx.ExecuteTemplateString(ctx, "{{ .test }}")
 		require.NoError(t, err)
 		assert.Equal(t, "fallback response", field)
 	})

--- a/pkg/engine/plan/action_v2.go
+++ b/pkg/engine/plan/action_v2.go
@@ -150,7 +150,9 @@ func (a *ActionV2) dispatchBackgroundChains(ctx context.Context, logger *zap.Log
 
 		logger.Debug("dispatching background chain", zap.String("dispatch_id", dispatchID))
 
+		endFlow := reqCtx.BeginFlow("dispatch:" + dispatchID)
 		bgMgr.Dispatch(func(bgCtx context.Context) {
+			defer endFlow() // FIRST: a panic or early return must still end the flow
 			// Detach the request context's cancellation so the chain survives the
 			// HTTP request completing, while retaining its values — crucially the
 			// live, recording OTEL span. Re-injecting only a remote span context

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -73,7 +73,7 @@ func TestPlan_Execute(t *testing.T) {
 	}{
 		{
 			name:         "success from response template",
-			startAction:  requestctx2.ActionConfigPrefix + "action1",
+			startAction:  apiconfig.ActionConfigPrefix + "action1",
 			contextSetup: func(ctx context.Context) {},
 			mockAssertions: func(exec1, exec2, exec3 *MockActionExecutable) {
 				exec1.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
@@ -84,7 +84,7 @@ func TestPlan_Execute(t *testing.T) {
 		},
 		{
 			name:         "chain without response step yields nil result",
-			startAction:  requestctx2.ActionConfigPrefix + "action2",
+			startAction:  apiconfig.ActionConfigPrefix + "action2",
 			contextSetup: func(ctx context.Context) {},
 			mockAssertions: func(exec1, exec2, exec3 *MockActionExecutable) {
 				exec2.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
@@ -104,7 +104,7 @@ func TestPlan_Execute(t *testing.T) {
 		},
 		{
 			name:        "execute in action",
-			startAction: requestctx2.ActionConfigPrefix + "action3",
+			startAction: apiconfig.ActionConfigPrefix + "action3",
 			contextSetup: func(ctx context.Context) {
 				requestctx2.AddRequestVariables(ctx, map[string]interface{}{"testValue": "test value"}, "")
 			},
@@ -113,7 +113,7 @@ func TestPlan_Execute(t *testing.T) {
 					DoAndReturn(func(ctx context.Context, _ string) (interface{}, map[string]string, error) {
 						// An action can re-enter the plan to run a sub-chain; the
 						// sub-chain has no response step, so it returns a nil result.
-						resp, err := ExecuteFromContext(ctx, requestctx2.ActionConfigPrefix+"action2")
+						resp, err := ExecuteFromContext(ctx, apiconfig.ActionConfigPrefix+"action2")
 						require.NoError(t, err)
 						assert.Nil(t, resp)
 						return "test value", nil, nil
@@ -367,7 +367,7 @@ func TestPlan_WorkspacePassedToActions(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := requestctx2.NewTestContext()
-			_, err = plan.Execute(ctx, requestctx2.ActionConfigPrefix+"test_action")
+			_, err = plan.Execute(ctx, apiconfig.ActionConfigPrefix+"test_action")
 			require.NoError(t, err)
 
 			if tc.expectNil {
@@ -435,6 +435,6 @@ func TestPlan_WorkspaceTemplateFunction(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := requestctx2.NewTestContext()
-	_, err = plan.Execute(ctx, requestctx2.ActionConfigPrefix+"test_action")
+	_, err = plan.Execute(ctx, apiconfig.ActionConfigPrefix+"test_action")
 	require.NoError(t, err)
 }

--- a/pkg/engine/plan/planner_test.go
+++ b/pkg/engine/plan/planner_test.go
@@ -179,41 +179,41 @@ func TestPlannerV2_Generate(t *testing.T) {
 
 		t.Run("check all items exist", func(t *testing.T) {
 			for id := range config.Actions {
-				assert.NotNil(t, plan.steps[requestctx.ActionConfigPrefix+id])
-				assert.IsType(t, &Action{}, plan.steps[requestctx.ActionConfigPrefix+id].step)
+				assert.NotNil(t, plan.steps[apiconfig.ActionConfigPrefix+id])
+				assert.IsType(t, &Action{}, plan.steps[apiconfig.ActionConfigPrefix+id].step)
 			}
 			for id := range config.Conditionals {
-				assert.NotNil(t, plan.steps[requestctx.ConditionalConfigPrefix+id])
-				assert.IsType(t, &ConditionStep{}, plan.steps[requestctx.ConditionalConfigPrefix+id].step)
+				assert.NotNil(t, plan.steps[apiconfig.ConditionalConfigPrefix+id])
+				assert.IsType(t, &ConditionStep{}, plan.steps[apiconfig.ConditionalConfigPrefix+id].step)
 			}
 			for id := range config.Responses {
-				assert.NotNil(t, plan.steps[requestctx.ResponsesConfigPrefix+id])
-				assert.IsType(t, &Response{}, plan.steps[requestctx.ResponsesConfigPrefix+id].step)
+				assert.NotNil(t, plan.steps[apiconfig.ResponsesConfigPrefix+id])
+				assert.IsType(t, &Response{}, plan.steps[apiconfig.ResponsesConfigPrefix+id].step)
 			}
 		})
 
 		t.Run("basic check of next", func(t *testing.T) {
-			assert.NotNil(t, plan.steps[requestctx.ActionConfigPrefix+"action1"])
+			assert.NotNil(t, plan.steps[apiconfig.ActionConfigPrefix+"action1"])
 
-			act, ok := plan.steps[requestctx.ActionConfigPrefix+"action1"].step.(*Action)
+			act, ok := plan.steps[apiconfig.ActionConfigPrefix+"action1"].step.(*Action)
 			require.True(t, ok, "expected action to be a *Action")
 
 			assert.IsType(t, &ConditionStep{}, act.next.step)
 		})
 
 		t.Run("Action Step with End", func(t *testing.T) {
-			assert.NotNil(t, plan.steps[requestctx.ActionConfigPrefix+"action2"])
+			assert.NotNil(t, plan.steps[apiconfig.ActionConfigPrefix+"action2"])
 
-			act, ok := plan.steps[requestctx.ActionConfigPrefix+"action2"].step.(*Action)
+			act, ok := plan.steps[apiconfig.ActionConfigPrefix+"action2"].step.(*Action)
 			require.True(t, ok, "expected action to be a *Action")
 
 			assert.Nil(t, act.next)
 		})
 
 		t.Run("Conditional Step", func(t *testing.T) {
-			assert.NotNil(t, plan.steps[requestctx.ConditionalConfigPrefix+"cond1"])
+			assert.NotNil(t, plan.steps[apiconfig.ConditionalConfigPrefix+"cond1"])
 
-			cond, ok := plan.steps[requestctx.ConditionalConfigPrefix+"cond1"].step.(*ConditionStep)
+			cond, ok := plan.steps[apiconfig.ConditionalConfigPrefix+"cond1"].step.(*ConditionStep)
 			require.True(t, ok, "expected conditional step to be a *ConditionStep")
 			assert.IsType(t, &Response{}, cond.OnValid.step)
 			assert.IsType(t, &Response{}, cond.OnInvalid.step)
@@ -263,8 +263,8 @@ func TestPlannerV2_Generate(t *testing.T) {
 		require.NoError(t, err)
 
 		for id := range config.Responses {
-			assert.NotNil(t, plan.steps[requestctx.ResponsesConfigPrefix+id])
-			assert.IsType(t, &Response{}, plan.steps[requestctx.ResponsesConfigPrefix+id].step)
+			assert.NotNil(t, plan.steps[apiconfig.ResponsesConfigPrefix+id])
+			assert.IsType(t, &Response{}, plan.steps[apiconfig.ResponsesConfigPrefix+id].step)
 		}
 	})
 }

--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -57,11 +57,8 @@ func (rc *RequestContext) TokenUsage() (input, output int64) {
 	return rc.tokenInput.Load(), rc.tokenOutput.Load()
 }
 
-// TODO move this and dpl together
-const errTag = "error"
-
 // AddValidationErrors gets the validation errors added by the various conditional template functions,
-// then adds the errors under the errTag in the request variable for parsing
+// then adds the errors under the ErrorTagStripped key in the request variable for parsing
 func AddValidationErrors(ctx context.Context) error {
 	reqCtx, err := FromContextOrError(ctx)
 	if err != nil {
@@ -72,7 +69,7 @@ func AddValidationErrors(ctx context.Context) error {
 	for i, err := range reqCtx.validationErrors {
 		errMessages[i] = err.Error()
 	}
-	reqCtx.addRequestVariables(map[string]interface{}{errTag: errMessages}, "")
+	reqCtx.addRequestVariables(map[string]interface{}{ErrorTagStripped: errMessages}, "")
 	return nil
 }
 

--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"text/template"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var ErrNoContext = errors.New("no context provided in request")
@@ -34,6 +36,13 @@ type RequestContext struct {
 	// Shared by pointer with child workflow contexts via ShareSecretsWith.
 	// Own mutex; never nil (see NewRequestContext).
 	secrets *secretTable
+
+	// spanAttrs are the request-wide attributes stamped on this request's root
+	// span by pkg/tracing. Set once in Start before the ctx is shared;
+	// read-only afterwards.
+	spanAttrs []attribute.KeyValue
+	// lc is the request completion latch (see lifecycle.go).
+	lc lifecycle
 }
 
 // AddTokenUsage adds LLM token usage to this request's running total. Safe for
@@ -103,6 +112,12 @@ func (rc *RequestContext) GetWorkspace() Workspace {
 	return rc.workspace
 }
 
+// NewRequestContext builds a bare RequestContext.
+//
+// Production entry points should NOT call this directly: open a request via
+// Start, which consolidates id generation, span attributes, the request
+// logger, template funcs and parent linking. NewRequestContext remains the
+// low-level constructor used by Start, tests and NewTestContext.
 func NewRequestContext(id string) *RequestContext {
 	return &RequestContext{
 		requestID:        id,

--- a/pkg/engine/requestctx/dpl.go
+++ b/pkg/engine/requestctx/dpl.go
@@ -58,105 +58,8 @@ func init() {
 
 }
 
-// ReplaceVariableValuesInContext scans the input string for placeholders formatted as {{key}}
-// and replaces each placeholder with the corresponding value from the provided map.
-// Placeholders are expected to be enclosed in double curly braces with an optional
-// amount of whitespace inside the braces around the key. The function performs a lookup
-// in the provided values map using the trimmed key and replaces the placeholder with the
-// value found. If a placeholder's key does not exist in the map, the placeholder is left
-// unchanged in the output string.
-//
-// Parameters:
-//   - in: The input string containing placeholders to be replaced. Placeholders should
-//     be in the format {{key}}, where key corresponds to a key in the values map.
-//   - values: A map[string]string where each key is a placeholder found in the input string
-//     without the curly braces and whitespace, and the value is the string to replace
-//     the placeholder with.
-//
-// Returns:
-//   - A string where all recognized placeholders have been replaced with corresponding
-//     values from the map. If a key from the placeholder is not found in the map, the
-//     placeholder remains unchanged in the returned string.
-//
-// Example Usage:
-//
-//	input := "Hello, {{name}}! Today is {{day}}."
-//	values in context := map[string]string{"name": "Alice", "day": "Wednesday"}
-//	result := ReplaceVariableValues(input, values)
-//	// result will be "Hello, Alice! Today is Wednesday."
-//
-// This function is useful in templating scenarios where dynamic data needs to be inserted
-// into a predefined format. It supports basic templating functionalities and is designed
-// to handle common use cases with simplicity and efficiency.
-//
-// Note:
-//   - The function is case-sensitive, which means that the keys in the values map must
-//     match exactly with the case used in the placeholders.
-//   - Extra spaces inside the placeholder braces are ignored, so '{{  name  }}' is treated
-//     as '{{name}}'.
-func ReplaceVariableValuesInContext(ctx context.Context, in string) (string, error) {
-	values, err := GetAllRequestVariables(ctx)
-	if err != nil {
-		return in, err
-	}
-	return ReplaceVariableValues(in, values)
-}
-
-func ReplaceVariableValues(in string, values map[string]interface{}) (string, error) {
-	tmpl, err := createTemplate(in, nil, false)
-	if err != nil {
-		return in, fmt.Errorf("error processing template: %w", err)
-	}
-	var buff bytes.Buffer
-	if err := tmpl.Execute(&buff, values); err != nil {
-		return "", fmt.Errorf("error processing template: %w", err)
-	}
-
-	return strings.ReplaceAll(buff.String(), noValue, ""), nil
-}
-
-// createTemplate creates a template using base functions only (no request context).
-// For v1 backward compatibility - used by ReplaceVariableValues.
-func createTemplate(in string, funcMap template.FuncMap, wrapJSON bool) (*template.Template, error) {
-	funcMap = getBaseFuncMap(funcMap)
-	replaced := replaceEscapedQuotes(in)
-	replaced = normalizeActionVariables(replaced)
-	if wrapJSON {
-		replaced = wrapWithJSON(replaced)
-	}
-	return template.New("input").Option("missingkey=zero").Funcs(funcMap).Parse(replaced)
-}
-
-// getBaseFuncMap returns base template functions without request context.
-// Used for backward compatibility with code that doesn't have a RequestContext.
-func getBaseFuncMap(funcMap template.FuncMap) template.FuncMap {
-	m := template.FuncMap{
-		"strip":        tmplStripText,
-		"jsonout":      jsonOut,
-		"pluck":        tmplPluck,
-		"escape":       stringEscape,
-		"stringescape": stringEscape,
-		"jsonraw":      jsonRaw,
-		"join":         tmplJoin,
-		"hash":         tmplHash,
-		"now":          now,
-		"secret":       secret,
-	}
-	for k, v := range funcMap {
-		m[k] = v
-	}
-	return m
-}
-
 func normalizeActionVariables(in string) string {
 	return strings.ReplaceAll(in, "."+VariableActionPrefix, ".")
-}
-
-// DEPRECATED jsonout will be added in action generation
-func wrapWithJSON(in string) string {
-	replaced := strings.ReplaceAll(in, "\"{{", "{{ jsonout (")
-	replaced = strings.ReplaceAll(replaced, "}}\"", ")}}")
-	return replaced
 }
 
 // replaceEscapedQuotes replaces escaped quotes (\") with
@@ -197,18 +100,6 @@ func CreateTextTemplate(reqCtx context.Context, config string, funcMap template.
 	}
 	// Use RequestContext's createTemplate which includes all functions (base + request-scoped)
 	return rCtx.createTemplate(config, funcMap)
-}
-
-func BaseParseTextTemplate(rawString string, funcMap template.FuncMap) (string, error) {
-	tmpl, err := createTemplate(rawString, funcMap, false)
-	if err != nil {
-		return "", err
-	}
-	var buff bytes.Buffer
-	if err := tmpl.Execute(&buff, nil); err != nil {
-		return "", fmt.Errorf("error processing template: %w", err)
-	}
-	return strings.ReplaceAll(buff.String(), noValue, ""), nil
 }
 
 func ExecuteTemplateFromContext(ctx context.Context, tmpl *template.Template) (string, error) {

--- a/pkg/engine/requestctx/dpl.go
+++ b/pkg/engine/requestctx/dpl.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-
-	"github.com/Servflow/servflow/pkg/apiconfig"
 )
 
 // TODO move to same package as requestctx
@@ -24,15 +22,20 @@ type DataType int
 
 const noValue = "<no value>"
 
+// Request-variable namespace constants. Unlike the step-reference prefixes
+// (whose canonical home is the apiconfig package), these describe how request
+// and action outputs are keyed in the request-variable map that templates
+// render against, so their home is here in the request layer.
 const (
-	// Step-reference prefixes moved to the apiconfig package (canonical home).
-	// Aliased here for backwards compatibility; prefer apiconfig.* in new code.
-	ActionConfigPrefix          = apiconfig.ActionConfigPrefix
-	ConditionalConfigPrefix     = apiconfig.ConditionalConfigPrefix
-	ResponsesConfigPrefix       = apiconfig.ResponsesConfigPrefix
+	// BareVariablesPrefixStripped prefixes every entry in the request-variable
+	// map; templates address them as "{{ .variable_... }}".
 	BareVariablesPrefixStripped = "variable_"
-	VariableActionPrefix        = BareVariablesPrefixStripped + "actions_"
-	ErrorTagStripped            = "error"
+	// VariableActionPrefix is the request-variable prefix under which an
+	// action's stored output lives ("variable_actions_<id>").
+	VariableActionPrefix = BareVariablesPrefixStripped + "actions_"
+	// ErrorTagStripped is the request-variable key under which conditional
+	// validation errors are collected.
+	ErrorTagStripped = "error"
 )
 
 const (

--- a/pkg/engine/requestctx/dpl_test.go
+++ b/pkg/engine/requestctx/dpl_test.go
@@ -100,12 +100,12 @@ func TestBackwardCompatibility(t *testing.T) {
 	err := AddRequestVariables(ctx, map[string]interface{}{"greet": map[string]interface{}{"message": "hello"}}, "")
 	require.NoError(t, err)
 
-	result, err := ReplaceVariableValuesInContext(ctx, "{{ .variable_actions_greet.message }}")
+	result, err := ExecuteTemplateString(ctx, "{{ .variable_actions_greet.message }}")
 	require.NoError(t, err)
 	assert.Equal(t, "hello", result)
 }
 
-func TestReplaceVariableValuesInContext(t *testing.T) {
+func TestExecuteTemplateStringVariables(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -193,10 +193,10 @@ func TestReplaceVariableValuesInContext(t *testing.T) {
 			ctx := NewTestContext()
 			err := AddRequestVariables(ctx, tt.values, "")
 			require.NoError(t, err)
-			result, err := ReplaceVariableValuesInContext(ctx, tt.input)
+			result, err := ExecuteTemplateString(ctx, tt.input)
 			require.NoError(t, err)
 			if result != tt.expected {
-				t.Errorf("ReplaceVariableValues(%q, %v) = %q, want %q", tt.input, tt.values, result, tt.expected)
+				t.Errorf("ExecuteTemplateString(%q, %v) = %q, want %q", tt.input, tt.values, result, tt.expected)
 			}
 		})
 	}
@@ -292,7 +292,7 @@ func TestCreateTextTemplate(t *testing.T) {
 	}
 }
 
-func TestBaseParseTextTemplate(t *testing.T) {
+func TestExecuteTemplateStringSecrets(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -334,7 +334,7 @@ func TestBaseParseTextTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := BaseParseTextTemplate(tt.input, nil)
+			result, err := ExecuteTemplateString(NewTestContext(), tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -413,59 +413,6 @@ func TestExecuteTemplateWithActionFunctionMap(t *testing.T) {
 				assert.Equal(t, tt.expected, result)
 			}
 		})
-	}
-}
-
-func TestWrapWithJSON(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "basic wrap test",
-			input:    "{\"key\": \"{{ data }}\"}",
-			expected: "{\"key\": {{ jsonout ( data )}}}",
-		},
-		{
-			name:     "nested wrap test",
-			input:    "{\"outerKey\": \"{{ innerKey }}\", \"anotherKey\": \"{{ anotherInnerKey }}\"}",
-			expected: "{\"outerKey\": {{ jsonout ( innerKey )}}, \"anotherKey\": {{ jsonout ( anotherInnerKey )}}}",
-		},
-		{
-			name:     "no template tags",
-			input:    "{\"key\": \"value\"}",
-			expected: "{\"key\": \"value\"}",
-		},
-		{
-			name:     "empty input",
-			input:    "",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := wrapWithJSON(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func BenchmarkReplaceVariableValuesInContext(b *testing.B) {
-	ctx := NewTestContext()
-	err := AddRequestVariables(ctx, map[string]interface{}{"variable1": "test", "variable2": "test2"}, "")
-	require.NoError(b, err)
-	input := "Start {{$variable1}} middle {{$variable2}} end."
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		in, err := ReplaceVariableValuesInContext(ctx, input)
-		if err != nil {
-			b.Fatal("Error in ReplaceVariableValuesInContext:", err)
-		}
-		if in != "Start test middle test2 end." {
-			b.Fatal("invalid value")
-		}
 	}
 }
 

--- a/pkg/engine/requestctx/file.go
+++ b/pkg/engine/requestctx/file.go
@@ -104,7 +104,7 @@ func GetFileFromContext(ctx context.Context, fileInput apiconfig.FileInput) (*Fi
 	case apiconfig.FileInputTypeRequest:
 		key = fileKeyRequestPrefix + fileInput.Identifier
 	case apiconfig.FileInputTypeAction:
-		key = fileKeyActionPrefix + strings.TrimPrefix(fileInput.Identifier, ActionConfigPrefix)
+		key = fileKeyActionPrefix + strings.TrimPrefix(fileInput.Identifier, apiconfig.ActionConfigPrefix)
 	case apiconfig.FileInputTypeStorage:
 		ws := reqCtx.GetWorkspace()
 		if ws == nil {

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -1,0 +1,206 @@
+package requestctx
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"text/template"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// Span attribute keys owned by the request layer. pkg/tracing aliases them
+// (it imports this package; the reverse would cycle).
+const (
+	// AttrRequestID is stamped on the request's root span via SpanAttributes.
+	AttrRequestID = "sf.request_id"
+)
+
+// flowDrainTimeout caps how long completion waits for child flows after
+// Done(). An un-ended span is never exported, so a hung flow must never leak
+// the root span — better a capped duration than a vanished trace.
+// Var, not const, so tests can shrink it.
+var flowDrainTimeout = 10 * time.Minute
+
+// lifecycle is the request's completion latch: the request completes when the
+// main flow is done AND every child flow has ended (or the drain cap fires).
+type lifecycle struct {
+	mu         sync.Mutex
+	rootSpan   trace.Span         // nil when tracing is disabled
+	beforeEnd  []func(trace.Span) // run right before rootSpan.End()
+	onComplete []func()           // run after completion (span ended or absent)
+	flows      int
+	mainDone   bool
+	completed  bool
+	timer      *time.Timer
+}
+
+// Options configures a request opened with Start.
+type Options struct {
+	// ID is the request id; "request_<unixnano>" is generated when empty.
+	ID string
+	// Logger is the base logger. Start attaches the request_id field, wraps it
+	// with the secret scrubber, and installs it in the returned ctx — the
+	// logger every step (logging.FromContext) sees. Nil skips logger setup.
+	Logger *zap.Logger
+	// SpanAttributes are appended to EVERY span created within this request
+	// (root and children) by pkg/tracing. sf.request_id is always added.
+	SpanAttributes []attribute.KeyValue
+	// TemplateFuncs seeds the request template function table.
+	TemplateFuncs template.FuncMap
+	// TemplateFuncsExclusive is the overwrite flag passed to
+	// AddRequestTemplateFunctions for the seeded funcs.
+	TemplateFuncsExclusive bool
+	// Parent links a sub-workflow to its caller: secrets are shared, and this
+	// request registers as a child flow of the parent, so the parent's total
+	// time transitively covers this request's entire lifetime.
+	Parent *RequestContext
+}
+
+// Start opens a request and its main flow. The caller MUST call Done() when
+// the main flow completes (response written / Execute returned) — typically
+// `defer rc.Done()` immediately after Start.
+func Start(ctx context.Context, opts Options) (context.Context, *RequestContext) {
+	id := opts.ID
+	if id == "" {
+		id = fmt.Sprintf("request_%d", time.Now().UnixNano())
+	}
+	rc := NewRequestContext(id)
+	rc.spanAttrs = append(append([]attribute.KeyValue{}, opts.SpanAttributes...),
+		attribute.String(AttrRequestID, id))
+	if len(opts.TemplateFuncs) > 0 {
+		rc.AddRequestTemplateFunctions(opts.TemplateFuncs, opts.TemplateFuncsExclusive)
+	}
+	if opts.Parent != nil {
+		opts.Parent.ShareSecretsWith(rc)
+		end := opts.Parent.BeginFlow("workflow:" + id)
+		rc.OnComplete(end)
+	}
+	ctx = WithAggregationContext(ctx, rc)
+	if opts.Logger != nil {
+		l := WrapWithScrubber(opts.Logger.With(zap.String("request_id", id)), rc)
+		ctx = WithLogger(ctx, l)
+	}
+	return ctx, rc
+}
+
+// SpanAttributes returns the request-wide span attributes. Set once in Start
+// before the ctx is shared; read-only afterwards.
+func (rc *RequestContext) SpanAttributes() []attribute.KeyValue {
+	return rc.spanAttrs
+}
+
+// BindRootSpan registers the request's root span and hooks to run immediately
+// before it ends. Called by pkg/tracing's root constructors. One root per
+// request: a second call overwrites (see pitfalls).
+func (rc *RequestContext) BindRootSpan(span trace.Span, beforeEnd ...func(trace.Span)) {
+	rc.lc.mu.Lock()
+	defer rc.lc.mu.Unlock()
+	rc.lc.rootSpan = span
+	rc.lc.beforeEnd = append(rc.lc.beforeEnd, beforeEnd...)
+}
+
+// BeginFlow registers a child flow (dispatch chain, sub-workflow). The
+// returned end func is idempotent and safe from any goroutine. name is
+// documentation/debugging only.
+//
+// Flow-count safety: first-level BeginFlow calls happen during plan execution
+// (before Done), and nested ones from within a still-open flow, so `flows`
+// cannot touch zero prematurely; an end() after a timeout-forced completion is
+// a no-op.
+func (rc *RequestContext) BeginFlow(name string) (end func()) {
+	_ = name
+	rc.lc.mu.Lock()
+	rc.lc.flows++
+	rc.lc.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			rc.lc.mu.Lock()
+			rc.lc.flows--
+			rc.lc.mu.Unlock()
+			rc.maybeComplete(false)
+		})
+	}
+}
+
+// OnComplete registers fn to run at full completion; fires immediately if the
+// request already completed. Span-agnostic: works with tracing disabled.
+func (rc *RequestContext) OnComplete(fn func()) {
+	rc.lc.mu.Lock()
+	if rc.lc.completed {
+		rc.lc.mu.Unlock()
+		fn()
+		return
+	}
+	rc.lc.onComplete = append(rc.lc.onComplete, fn)
+	rc.lc.mu.Unlock()
+}
+
+// Done marks the main flow complete. Non-blocking. The request fully completes
+// — root span End (Duration = TOTAL time), request files closed, OnComplete
+// callbacks — once Done has been called AND every BeginFlow has ended, or at
+// flowDrainTimeout.
+func (rc *RequestContext) Done() {
+	rc.lc.mu.Lock()
+	if rc.lc.mainDone {
+		rc.lc.mu.Unlock()
+		return
+	}
+	rc.lc.mainDone = true
+	if rc.lc.flows > 0 {
+		rc.lc.timer = time.AfterFunc(flowDrainTimeout, func() { rc.maybeComplete(true) })
+	}
+	rc.lc.mu.Unlock()
+	rc.maybeComplete(false)
+}
+
+// maybeComplete finishes the request exactly once, when the main flow is done
+// and child flows have drained (or force, on drain timeout). Effects run
+// outside the lock, in order: beforeEnd hooks → root span End → close request
+// files → OnComplete callbacks.
+func (rc *RequestContext) maybeComplete(force bool) {
+	rc.lc.mu.Lock()
+	if rc.lc.completed || !rc.lc.mainDone || (rc.lc.flows > 0 && !force) {
+		rc.lc.mu.Unlock()
+		return
+	}
+	rc.lc.completed = true
+	if rc.lc.timer != nil {
+		rc.lc.timer.Stop()
+	}
+	span := rc.lc.rootSpan
+	beforeEnd := rc.lc.beforeEnd
+	onComplete := rc.lc.onComplete
+	rc.lc.onComplete = nil
+	rc.lc.mu.Unlock()
+
+	if span != nil {
+		for _, fn := range beforeEnd {
+			fn(span)
+		}
+		span.End()
+	}
+	rc.closeFiles()
+	for _, fn := range onComplete {
+		fn()
+	}
+}
+
+// closeFiles closes every request file. Runs once at completion (not at Done:
+// child flows may still read request files after the response is written).
+// Close errors (incl. double-close) are ignored — cleanup is best-effort.
+func (rc *RequestContext) closeFiles() {
+	rc.Lock()
+	files := make([]*FileValue, 0, len(rc.availableFiles))
+	for _, f := range rc.availableFiles {
+		files = append(files, f)
+	}
+	rc.Unlock()
+	for _, f := range files {
+		_ = f.Close()
+	}
+}

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -77,7 +77,7 @@ func Start(ctx context.Context, opts Options) (context.Context, *RequestContext)
 	if opts.Parent != nil {
 		opts.Parent.ShareSecretsWith(rc)
 		end := opts.Parent.BeginFlow("workflow:" + id)
-		rc.OnComplete(end)
+		rc.RegisterOnCompleteHook(end)
 	}
 	ctx = WithAggregationContext(ctx, rc)
 	if opts.Logger != nil {
@@ -127,9 +127,9 @@ func (rc *RequestContext) BeginFlow(name string) (end func()) {
 	}
 }
 
-// OnComplete registers fn to run at full completion; fires immediately if the
+// RegisterOnCompleteHook registers fn to run at full completion; fires immediately if the
 // request already completed. Span-agnostic: works with tracing disabled.
-func (rc *RequestContext) OnComplete(fn func()) {
+func (rc *RequestContext) RegisterOnCompleteHook(fn func()) {
 	rc.lc.mu.Lock()
 	if rc.lc.completed {
 		rc.lc.mu.Unlock()
@@ -141,7 +141,7 @@ func (rc *RequestContext) OnComplete(fn func()) {
 }
 
 // Done marks the main flow complete. Non-blocking. The request fully completes
-// — root span End (Duration = TOTAL time), request files closed, OnComplete
+// — root span End (Duration = TOTAL time), request files closed, RegisterOnCompleteHook
 // callbacks — once Done has been called AND every BeginFlow has ended, or at
 // flowDrainTimeout.
 func (rc *RequestContext) Done() {
@@ -161,7 +161,7 @@ func (rc *RequestContext) Done() {
 // maybeComplete finishes the request exactly once, when the main flow is done
 // and child flows have drained (or force, on drain timeout). Effects run
 // outside the lock, in order: beforeEnd hooks → root span End → close request
-// files → OnComplete callbacks.
+// files → RegisterOnCompleteHook callbacks.
 func (rc *RequestContext) maybeComplete(force bool) {
 	rc.lc.mu.Lock()
 	if rc.lc.completed || !rc.lc.mainDone || (rc.lc.flows > 0 && !force) {

--- a/pkg/engine/requestctx/lifecycle_test.go
+++ b/pkg/engine/requestctx/lifecycle_test.go
@@ -1,0 +1,363 @@
+package requestctx
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newRecorder returns a span recorder and a tracer sourced from a provider
+// wired to it, for observing End and attributes without touching global state.
+func newRecorder() (*tracetest.SpanRecorder, trace.Tracer) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	return sr, tp.Tracer("lifecycle_test")
+}
+
+// startSpan opens a fresh root span from tr, returning it and the ctx it lives
+// in.
+func startSpan(tr trace.Tracer) (context.Context, trace.Span) {
+	return tr.Start(context.Background(), "root")
+}
+
+// attrValue returns the value of key on the first ended span, or false.
+func attrValue(spans []sdktrace.ReadOnlySpan, key string) (attribute.Value, bool) {
+	for _, s := range spans {
+		for _, kv := range s.Attributes() {
+			if string(kv.Key) == key {
+				return kv.Value, true
+			}
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// Case 1: Start → Done, no flows → span ended immediately.
+func TestLifecycle_StartDoneNoFlows(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r1"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span)
+
+	rc.Done()
+
+	require.Len(t, sr.Ended(), 1, "root span should end immediately with no flows")
+}
+
+// Case 2: BeginFlow x2 → Done → NOT ended → end() x2 → ended exactly once.
+func TestLifecycle_FlowsDrainBeforeEnd(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r2"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span)
+
+	end1 := rc.BeginFlow("a")
+	end2 := rc.BeginFlow("b")
+
+	rc.Done()
+	assert.Len(t, sr.Ended(), 0, "span must not end while flows are open")
+
+	end1()
+	assert.Len(t, sr.Ended(), 0, "span must not end with one flow still open")
+
+	end2()
+	assert.Len(t, sr.Ended(), 1, "span ends exactly once after all flows drain")
+}
+
+// Case 3: end() before Done → Done ends immediately.
+func TestLifecycle_EndBeforeDone(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r3"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span)
+
+	end := rc.BeginFlow("a")
+	end()
+	assert.Len(t, sr.Ended(), 0, "flow ended but main not done yet")
+
+	rc.Done()
+	assert.Len(t, sr.Ended(), 1)
+}
+
+// Case 4: the same end() called twice → only one decrement.
+func TestLifecycle_EndIdempotent(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r4"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span)
+
+	end1 := rc.BeginFlow("a")
+	end2 := rc.BeginFlow("b")
+
+	rc.Done()
+	end1()
+	end1() // duplicate — must NOT over-decrement and complete early
+	assert.Len(t, sr.Ended(), 0, "duplicate end must not prematurely complete")
+
+	end2()
+	assert.Len(t, sr.Ended(), 1)
+}
+
+// Case 5: timeout — BeginFlow, Done, never end → span ends via drain cap;
+// late end() is a no-op.
+func TestLifecycle_DrainTimeout(t *testing.T) {
+	old := flowDrainTimeout
+	flowDrainTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { flowDrainTimeout = old })
+
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r5"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span)
+
+	end := rc.BeginFlow("stuck")
+	rc.Done()
+	assert.Len(t, sr.Ended(), 0)
+
+	require.Eventually(t, func() bool { return len(sr.Ended()) == 1 }, time.Second, 5*time.Millisecond,
+		"span should end at drain timeout")
+
+	end() // late — no-op, no panic, no double end
+	assert.Len(t, sr.Ended(), 1)
+}
+
+// Case 6: no bound span — Done + OnComplete fire fine (tracing-disabled path).
+func TestLifecycle_NoSpan(t *testing.T) {
+	_, rc := Start(context.Background(), Options{ID: "r6"})
+	var called atomic.Bool
+	rc.OnComplete(func() { called.Store(true) })
+	rc.Done()
+	assert.True(t, called.Load(), "OnComplete must fire even with no span")
+}
+
+// Case 7: Parent — child completes gate the parent completion, transitively.
+func TestLifecycle_ParentChildNesting(t *testing.T) {
+	sr, tr := newRecorder()
+
+	_, parent := Start(context.Background(), Options{ID: "parent"})
+	_, pspan := startSpan(tr)
+	parent.BindRootSpan(pspan)
+
+	// child registered as a flow of parent via Parent option.
+	_, child := Start(context.Background(), Options{ID: "child", Parent: parent})
+	_, cspan := startSpan(tr)
+	child.BindRootSpan(cspan)
+
+	// give the child its own flow, to prove transitivity.
+	childFlow := child.BeginFlow("child-bg")
+
+	parent.Done()
+	assert.Len(t, sr.Ended(), 0, "parent has an open child flow")
+
+	child.Done()
+	assert.Len(t, sr.Ended(), 0, "child still has an open background flow")
+
+	childFlow()
+	// child completes → its OnComplete ends the parent's flow → parent completes.
+	require.Len(t, sr.Ended(), 2)
+	// parent must end no earlier than child.
+	assert.GreaterOrEqual(t, pspan.(sdktrace.ReadOnlySpan).EndTime().UnixNano(),
+		cspan.(sdktrace.ReadOnlySpan).EndTime().UnixNano(),
+		"parent EndTime >= child EndTime")
+}
+
+// Case 8: beforeEnd hooks observe the span before End.
+func TestLifecycle_BeforeEndHook(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r8"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span, func(s trace.Span) {
+		s.SetAttributes(attribute.String("hooked", "yes"))
+	})
+	rc.Done()
+
+	require.Len(t, sr.Ended(), 1)
+	v, ok := attrValue(sr.Ended(), "hooked")
+	require.True(t, ok)
+	assert.Equal(t, "yes", v.AsString())
+}
+
+// Case 9: Start seeds template funcs and generates an id when opts.ID == "".
+func TestLifecycle_StartSeedsFuncsAndID(t *testing.T) {
+	_, rc := Start(context.Background(), Options{
+		TemplateFuncs: template.FuncMap{"foo": func() string { return "bar" }},
+	})
+	assert.NotEmpty(t, rc.ID())
+	assert.Contains(t, rc.ID(), "request_")
+	_, ok := rc.TemplateFunctions()["foo"]
+	assert.True(t, ok, "seeded template func should be present")
+
+	// generated ids are stamped as the request-wide span attr too.
+	found := false
+	for _, kv := range rc.SpanAttributes() {
+		if string(kv.Key) == AttrRequestID && kv.Value.AsString() == rc.ID() {
+			found = true
+		}
+	}
+	assert.True(t, found, "sf.request_id span attr should match id")
+}
+
+// Case 10: Start-installed logger scrubs tracked secrets.
+func TestLifecycle_StartLoggerScrubs(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	base := zap.New(core)
+
+	ctx, rc := Start(context.Background(), Options{ID: "r10", Logger: base})
+	rc.secrets.track("MY_SECRET", "supersecretvalue")
+
+	l := loggerFrom(t, ctx)
+	l.Info("leaking supersecretvalue here")
+
+	require.Equal(t, 1, logs.Len())
+	assert.NotContains(t, logs.All()[0].Message, "supersecretvalue")
+	assert.Contains(t, logs.All()[0].Message, "«sf:MY_SECRET»")
+}
+
+// Case 11: file cleanup timing — files close at completion, not Done; double
+// close harmless.
+func TestLifecycle_FileCleanupTiming(t *testing.T) {
+	_, rc := Start(context.Background(), Options{ID: "r11"})
+	rec := &recordCloser{}
+	fv := NewFileValue(rec, "f")
+	rc.Lock()
+	rc.availableFiles["f"] = fv
+	rc.Unlock()
+
+	end := rc.BeginFlow("bg")
+	rc.Done()
+	assert.Equal(t, int32(0), rec.closes.Load(), "file must not close before flow drains")
+
+	end()
+	assert.Equal(t, int32(1), rec.closes.Load(), "file closes once at completion")
+
+	// manual re-close tolerated.
+	rc.closeFiles()
+	assert.LessOrEqual(t, rec.closes.Load(), int32(1), "double close is a no-op (idempotent Close)")
+}
+
+// Case 13: late tokens — tokens added after Done, before drain, land in the
+// exported root via the beforeEnd hook.
+func TestLifecycle_LateTokensStamped(t *testing.T) {
+	sr, tr := newRecorder()
+	_, rc := Start(context.Background(), Options{ID: "r13"})
+	_, span := startSpan(tr)
+	rc.BindRootSpan(span, func(s trace.Span) {
+		in, out := rc.TokenUsage()
+		s.SetAttributes(attribute.Int64("usage.total", in+out))
+	})
+
+	end := rc.BeginFlow("bg")
+	rc.Done()
+	rc.AddTokenUsage(100, 50) // background tokens after response
+	end()
+
+	require.Len(t, sr.Ended(), 1)
+	v, ok := attrValue(sr.Ended(), "usage.total")
+	require.True(t, ok)
+	assert.Equal(t, int64(150), v.AsInt64(), "late tokens included in exported total")
+}
+
+// Ordering shuffle: the six interleavings of {BeginFlow, Done, end} for a
+// single flow all end the span exactly once.
+func TestLifecycle_OrderingShuffle(t *testing.T) {
+	type step int
+	const (
+		begin step = iota
+		done
+		end
+	)
+	// only orderings where begin precedes end are meaningful (end is the
+	// return of begin); enumerate valid permutations.
+	orders := [][]step{
+		{begin, done, end},
+		{begin, end, done},
+		{done, begin, end}, // Done before any flow begins
+	}
+	for i, order := range orders {
+		sr, tr := newRecorder()
+		_, rc := Start(context.Background(), Options{ID: "ord"})
+		_, span := startSpan(tr)
+		rc.BindRootSpan(span)
+		var endFn func()
+		for _, s := range order {
+			switch s {
+			case begin:
+				endFn = rc.BeginFlow("f")
+			case done:
+				rc.Done()
+			case end:
+				if endFn != nil {
+					endFn()
+				}
+			}
+		}
+		assert.Len(t, sr.Ended(), 1, "ordering %d must end span exactly once", i)
+	}
+}
+
+// Stress: many concurrent flows + a Done at a random-ish point; exactly one
+// completion, one ended span. Run with -race.
+func TestLifecycle_StressConcurrent(t *testing.T) {
+	for iter := 0; iter < 50; iter++ {
+		sr, tr := newRecorder()
+		_, rc := Start(context.Background(), Options{ID: "stress"})
+		_, span := startSpan(tr)
+		rc.BindRootSpan(span)
+
+		var completions atomic.Int32
+		rc.OnComplete(func() { completions.Add(1) })
+
+		const N = 100
+		var wg sync.WaitGroup
+		ends := make([]func(), N)
+		for i := 0; i < N; i++ {
+			ends[i] = rc.BeginFlow("f")
+		}
+		wg.Add(N)
+		for i := 0; i < N; i++ {
+			go func(i int) {
+				defer wg.Done()
+				// jitter without Math.random: derive from index+iter.
+				time.Sleep(time.Duration((i*7+iter)%3) * time.Millisecond)
+				ends[i]()
+			}(i)
+		}
+		// Done fires concurrently with the ends.
+		go rc.Done()
+
+		wg.Wait()
+		rc.Done() // ensure Done happened at least once
+		require.Eventually(t, func() bool { return len(sr.Ended()) == 1 }, time.Second, time.Millisecond)
+		assert.Equal(t, int32(1), completions.Load(), "exactly one completion")
+	}
+}
+
+// --- helpers ---
+
+type recordCloser struct{ closes atomic.Int32 }
+
+func (r *recordCloser) Read(p []byte) (int, error) { return 0, io.EOF }
+func (r *recordCloser) Close() error {
+	r.closes.Add(1)
+	return nil
+}
+
+func loggerFrom(t *testing.T, ctx context.Context) *zap.Logger {
+	t.Helper()
+	l, ok := LoggerFromContext(ctx)
+	require.True(t, ok, "Start should install a logger")
+	return l
+}

--- a/pkg/engine/requestctx/lifecycle_test.go
+++ b/pkg/engine/requestctx/lifecycle_test.go
@@ -138,7 +138,7 @@ func TestLifecycle_DrainTimeout(t *testing.T) {
 func TestLifecycle_NoSpan(t *testing.T) {
 	_, rc := Start(context.Background(), Options{ID: "r6"})
 	var called atomic.Bool
-	rc.OnComplete(func() { called.Store(true) })
+	rc.RegisterOnCompleteHook(func() { called.Store(true) })
 	rc.Done()
 	assert.True(t, called.Load(), "OnComplete must fire even with no span")
 }
@@ -318,7 +318,7 @@ func TestLifecycle_StressConcurrent(t *testing.T) {
 		rc.BindRootSpan(span)
 
 		var completions atomic.Int32
-		rc.OnComplete(func() { completions.Add(1) })
+		rc.RegisterOnCompleteHook(func() { completions.Add(1) })
 
 		const N = 100
 		var wg sync.WaitGroup

--- a/pkg/engine/requestctx/logger.go
+++ b/pkg/engine/requestctx/logger.go
@@ -1,0 +1,23 @@
+package requestctx
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// loggerCtxKey stores the request logger in a context. It lives here (not in
+// pkg/logging, which imports this package) so Start can install the
+// fully-built request logger; pkg/logging delegates to these primitives.
+type loggerCtxKey struct{}
+
+// WithLogger stores the request logger in ctx.
+func WithLogger(ctx context.Context, l *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerCtxKey{}, l)
+}
+
+// LoggerFromContext returns the logger installed by WithLogger, if any.
+func LoggerFromContext(ctx context.Context) (*zap.Logger, bool) {
+	l, ok := ctx.Value(loggerCtxKey{}).(*zap.Logger)
+	return l, ok
+}

--- a/pkg/engine/requestctx/scrub.go
+++ b/pkg/engine/requestctx/scrub.go
@@ -1,0 +1,79 @@
+package requestctx
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Scrubber removes tracked secret values from a string. Implemented by
+// *RequestContext in this package; declared as an interface so the wrapping
+// stays decoupled from any particular implementation.
+type Scrubber interface {
+	// HasSecrets is the fast path: when false (the request resolved no
+	// secrets), scrubbing is skipped entirely and logging costs nothing extra.
+	HasSecrets() bool
+	Scrub(string) string
+}
+
+// WrapWithScrubber returns a logger whose output is scrubbed of any secret
+// values resolved during the request owning s. Install once at request entry;
+// every logger derived from it (via With/FromContext) inherits the scrubbing.
+func WrapWithScrubber(l *zap.Logger, s Scrubber) *zap.Logger {
+	if s == nil {
+		return l
+	}
+	return l.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		return &scrubCore{Core: c, s: s}
+	}))
+}
+
+// scrubCore is a zapcore.Core wrapper that scrubs entry messages and
+// string-ish fields on write. Fields attached via With() are scrubbed at
+// attach time (best effort — values tracked after attach but logged later
+// through such fields bypass scrubbing; call-site fields never do).
+type scrubCore struct {
+	zapcore.Core
+	s Scrubber
+}
+
+func (c *scrubCore) With(fields []zapcore.Field) zapcore.Core {
+	return &scrubCore{Core: c.Core.With(c.scrubFields(fields)), s: c.s}
+}
+
+func (c *scrubCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c *scrubCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	if !c.s.HasSecrets() {
+		return c.Core.Write(ent, fields)
+	}
+	ent.Message = c.s.Scrub(ent.Message)
+	return c.Core.Write(ent, c.scrubFields(fields))
+}
+
+func (c *scrubCore) scrubFields(fields []zapcore.Field) []zapcore.Field {
+	if !c.s.HasSecrets() {
+		return fields
+	}
+	out := make([]zapcore.Field, len(fields))
+	copy(out, fields)
+	for i := range out {
+		switch out[i].Type {
+		case zapcore.StringType:
+			out[i].String = c.s.Scrub(out[i].String)
+		case zapcore.ByteStringType:
+			if b, ok := out[i].Interface.([]byte); ok {
+				out[i].Interface = []byte(c.s.Scrub(string(b)))
+			}
+		case zapcore.ErrorType:
+			if err, ok := out[i].Interface.(error); ok {
+				out[i] = zapcore.Field{Key: out[i].Key, Type: zapcore.StringType, String: c.s.Scrub(err.Error())}
+			}
+		}
+	}
+	return out
+}

--- a/pkg/engine/server/handler.go
+++ b/pkg/engine/server/handler.go
@@ -62,10 +62,13 @@ func (e *Engine) createBasicHandler(config *apiconfig.APIConfig) (http.Handler, 
 		p:             p,
 		handlerType:   config.HttpConfig.Handler,
 		handlerConfig: config.HttpConfig.HandlerConfig,
+		baseLogger:    e.logger,
 	}
 
 	if e.configSpanAttrs != nil {
-		a.extraSpanAttrs = e.configSpanAttrs(config)
+		for k, v := range e.configSpanAttrs(config) {
+			a.spanAttrs = append(a.spanAttrs, attribute.String(k, v))
+		}
 	}
 
 	return a.CreateChain(config, e.getCorsConfig()), nil
@@ -83,9 +86,13 @@ type APIHandler struct {
 	// handlerConfig is the raw config for the entry handler, made available to
 	// the middleware via entryhandlers.WithConfig.
 	handlerConfig map[string]interface{}
-	// extraSpanAttrs are host-supplied attributes stamped on the root entry
-	// span (e.g. sf.agent), resolved once when this handler was built.
-	extraSpanAttrs map[string]string
+	// baseLogger is the engine logger; ServeHTTP derives the request logger
+	// from it via requestctx.Start.
+	baseLogger *zap.Logger
+	// spanAttrs are host-supplied request-wide span attributes (e.g. sf.agent),
+	// resolved when this handler was built and applied to every span of each
+	// request via requestctx.Start.
+	spanAttrs []attribute.KeyValue
 }
 
 const mcpServerVersion = "0.1.0"
@@ -141,10 +148,6 @@ func (h *APIHandler) initTracing(req *http.Request) (context.Context, trace.Span
 		attribute.String("sf.http.path", req.URL.Path),
 	)
 
-	for k, v := range h.extraSpanAttrs {
-		span.SetAttributes(attribute.String(k, v))
-	}
-
 	// Add query parameters to trace
 	queryParams := req.URL.Query()
 	for key, values := range queryParams {
@@ -172,37 +175,31 @@ func (h *APIHandler) initTracing(req *http.Request) (context.Context, trace.Span
 // ServeHttp extracts the context parameters and begins excuting the plan (step)
 func (h *APIHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	start := time.Now()
-	ctx := req.Context()
+	if h.baseLogger == nil {
+		h.baseLogger = zap.NewNop()
+	}
+	ctx, rectx := requestctx.Start(req.Context(), requestctx.Options{
+		Logger: h.baseLogger.With(
+			zap.String("method", req.Method), zap.String("path", req.URL.Path)),
+		SpanAttributes: h.spanAttrs,
+	})
+	req = req.WithContext(ctx)
+	// The lifecycle (bound in StartHTTPEntry) owns the root span: Done stamps
+	// the token totals and ends it once dispatched chains drain — root Duration
+	// = the request's true total time.
+	defer rectx.Done()
 	logger := logging.FromContext(ctx)
 	logger.Debug("Handling request")
 
 	ctx, span := h.initTracing(req)
-	if span != nil {
-		defer span.End()
-		// Registered after span.End so it runs first (LIFO): attach the
-		// request-level token total before the root span closes.
-		defer tracing.SetRequestTokens(ctx, span)
-	}
 
-	rectx, ok := requestctx.FromContext(ctx)
-	if !ok {
-		logger.Error("Could not get request context")
-		tracing.SetHTTPStatus(span, http.StatusInternalServerError, errors.New("could not get request context"))
-		http.Error(wr, "Error processing request", http.StatusInternalServerError)
-		return
-	}
-
-	if span != nil {
-		span.SetAttributes(attribute.String("sf.request_id", rectx.ID()))
-	}
 	// Derive the request/context copy FIRST, then bind the template functions to
 	// that same copy — the one the entry-handler middleware (and the plan) will
 	// serve. requestTemplateFunctions' `body` closure reads req.Body lazily; an
 	// entry handler that reads and restores the body (e.g. github_webhook's HMAC
 	// check) reassigns Body on the request it is handed, so the `body` function
-	// must be captured on that same *http.Request. Capturing it on the pre-copy
-	// request instead leaves `body "..."` reading a drained reader (renders
-	// empty) once a handler has consumed the body.
+	// must be captured on that same *http.Request. initTracing has already
+	// read-and-restored the body onto this req before the copy.
 	ctx = plan.WithRequest(ctx, req)
 	req = req.WithContext(ctx)
 

--- a/pkg/engine/server/mcp_handler.go
+++ b/pkg/engine/server/mcp_handler.go
@@ -10,6 +10,7 @@ import (
 	apiconfig "github.com/Servflow/servflow/pkg/apiconfig"
 	"github.com/Servflow/servflow/pkg/engine/plan"
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/Servflow/servflow/pkg/logging"
 	"github.com/Servflow/servflow/pkg/tracing"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -62,29 +63,28 @@ func (e *Engine) createMCPHandler(config *apiconfig.APIConfig) error {
 
 	e.mcpServer.AddTool(mcp.NewTool(config.McpTool.Name, options...), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		start := time.Now()
-		logger := logger.With(zap.String("tool_name", config.McpTool.Name))
 
-		reqCtx, ok := requestctx.FromContext(ctx)
-		if !ok {
-			logger.Error("could not get request context")
-			return nil, fmt.Errorf("error handling request")
-		}
+		ctx, reqCtx := requestctx.Start(ctx, requestctx.Options{
+			Logger: logger.With(zap.String("tool_name", config.McpTool.Name)),
+			TemplateFuncs: template.FuncMap{
+				"tool_param": func(key string) string {
+					args := request.GetArguments()
+					r, ok := args[key].(string)
+					if !ok {
+						return ""
+					}
 
-		// TODO add unit test for this
-		reqCtx.AddRequestTemplateFunctions(template.FuncMap{
-			"tool_param": func(key string) string {
-				args := request.GetArguments()
-				r, ok := args[key].(string)
-				if !ok {
-					return ""
-				}
-
-				return r
+					return r
+				},
 			},
-		}, true)
+			TemplateFuncsExclusive: true,
+		})
+		// The lifecycle owns the MCP root span (bound in StartMCPTool): Done
+		// ends it once any dispatched chains drain.
+		defer reqCtx.Done()
+		logger := logging.FromContext(ctx)
 
-		ctx, span := tracing.StartMCPTool(ctx, config.McpTool.Name)
-		defer span.End()
+		ctx, _ = tracing.StartMCPTool(ctx, config.McpTool.Name) // lifecycle-owned; no manual End
 
 		if _, err := p.Execute(ctx, config.McpTool.Start); err != nil {
 			logger.Error("error executing planner", zap.Error(err))

--- a/pkg/engine/server/request_hook_test.go
+++ b/pkg/engine/server/request_hook_test.go
@@ -62,7 +62,7 @@ func TestRequestHook(t *testing.T) {
 				requestHook: tt.hook,
 			}
 
-			wrappedHandler := engine.wrapMiddlewareWithReqIDLogger(logger, testHandler)
+			wrappedHandler := engine.wrapMiddleware(testHandler)
 
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 			w := httptest.NewRecorder()
@@ -93,7 +93,7 @@ func TestRequestHookHasAccessToEnrichedContext(t *testing.T) {
 		requestHook: hook,
 	}
 
-	wrappedHandler := engine.wrapMiddlewareWithReqIDLogger(logger, testHandler)
+	wrappedHandler := engine.wrapMiddleware(testHandler)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
@@ -119,7 +119,7 @@ func TestRequestHookWithEngineOption(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrappedHandler := engine.wrapMiddlewareWithReqIDLogger(engine.logger, testHandler)
+	wrappedHandler := engine.wrapMiddleware(testHandler)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
@@ -147,7 +147,7 @@ func TestRequestHookCanModifyResponse(t *testing.T) {
 		requestHook: hook,
 	}
 
-	wrappedHandler := engine.wrapMiddlewareWithReqIDLogger(logger, testHandler)
+	wrappedHandler := engine.wrapMiddleware(testHandler)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()

--- a/pkg/engine/server/server.go
+++ b/pkg/engine/server/server.go
@@ -1,15 +1,12 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"strings"
-	"time"
 
 	apiconfig "github.com/Servflow/servflow/pkg/apiconfig"
 	"github.com/Servflow/servflow/pkg/engine/plan"
-	"github.com/Servflow/servflow/pkg/engine/requestctx"
 	"github.com/Servflow/servflow/pkg/logging"
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
@@ -59,7 +56,7 @@ func (e *Engine) createMuxHandler(configs []*apiconfig.APIConfig) *mux.Router {
 			continue
 		}
 
-		h := e.wrapMiddlewareWithReqIDLogger(e.logger, handler)
+		h := e.wrapMiddleware(handler)
 		logger.Info("registered handler", zap.String("config_id", conf.ID))
 
 		r.Handle(listenPath, h).Methods(method, http.MethodOptions)
@@ -67,23 +64,20 @@ func (e *Engine) createMuxHandler(configs []*apiconfig.APIConfig) *mux.Router {
 
 	if e.mcpServer != nil {
 		httpHandler := server.NewStreamableHTTPServer(e.mcpServer)
-		r.HandleFunc("/mcp", e.wrapMiddlewareWithReqIDLogger(e.logger, httpHandler).ServeHTTP).Methods(http.MethodGet, http.MethodOptions, http.MethodPost)
+		r.HandleFunc("/mcp", e.wrapMiddleware(httpHandler).ServeHTTP).Methods(http.MethodGet, http.MethodOptions, http.MethodPost)
 	}
 
 	return r
 }
 
-func (e *Engine) wrapMiddlewareWithReqIDLogger(logger *zap.Logger, handler http.Handler) http.Handler {
+// wrapMiddleware installs the process-level concerns shared by every request:
+// idle-timer reset, the background manager, and the request hook. The
+// request-scoped facilities (request id, RequestContext, logger, span
+// attributes) are opened by the terminal handlers via requestctx.Start.
+func (e *Engine) wrapMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		e.resetIdleTimer()
-		requestID := fmt.Sprintf("request_%d", time.Now().UnixNano())
-		aggCtx := requestctx.NewRequestContext(requestID)
-		ctx := requestctx.WithAggregationContext(r.Context(), aggCtx)
-		logger := logger.With(zap.String("request_id", requestID), zap.String("method", r.Method), zap.String("path", r.URL.Path))
-		// Scrub any secret values revealed during this request from every log
-		// line derived from this logger (no-op until a reveal happens).
-		logger = logging.WrapWithScrubber(logger, aggCtx)
-		ctx = logging.WithLogger(ctx, logger)
+		ctx := r.Context()
 		if e.backgroundManager != nil {
 			ctx = plan.WithBackgroundManager(ctx, e.backgroundManager)
 		}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -53,12 +53,9 @@ func GetNewLogger() *zap.Logger {
 	return root
 }
 
-// loggerKey is the context key for storing logger instances
-type loggerKey struct{}
-
 // WithLogger adds a logger to the context
 func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
-	return context.WithValue(ctx, loggerKey{}, logger)
+	return requestctx.WithLogger(ctx, logger)
 }
 
 // FromContext retrieves a logger from the context.
@@ -67,7 +64,7 @@ func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
 // resolved secrets must not be able to log them through the fallback path.
 func FromContext(ctx context.Context) *zap.Logger {
 	if ctx != nil {
-		if logger, ok := ctx.Value(loggerKey{}).(*zap.Logger); ok {
+		if logger, ok := requestctx.LoggerFromContext(ctx); ok {
 			return logger
 		}
 		if rc, ok := requestctx.FromContext(ctx); ok {

--- a/pkg/logging/scrub.go
+++ b/pkg/logging/scrub.go
@@ -2,78 +2,15 @@ package logging
 
 import (
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
 )
 
-// Scrubber removes tracked secret values from a string. Implemented by
-// *requestctx.RequestContext; declared here as an interface so the logging
-// package stays decoupled from the request layer.
-type Scrubber interface {
-	// HasSecrets is the fast path: when false (the request resolved no
-	// secrets), scrubbing is skipped entirely and logging costs nothing extra.
-	HasSecrets() bool
-	Scrub(string) string
-}
+// Scrubber and WrapWithScrubber moved to requestctx (so requestctx.Start can
+// wrap the request logger without importing this package); re-exported here
+// to keep the logging API stable.
+type Scrubber = requestctx.Scrubber
 
-// WrapWithScrubber returns a logger whose output is scrubbed of any secret
-// values resolved during the request owning s. Install once at request entry;
-// every logger derived from it (via With/FromContext) inherits the scrubbing.
 func WrapWithScrubber(l *zap.Logger, s Scrubber) *zap.Logger {
-	if s == nil {
-		return l
-	}
-	return l.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
-		return &scrubCore{Core: c, s: s}
-	}))
-}
-
-// scrubCore is a zapcore.Core wrapper that scrubs entry messages and
-// string-ish fields on write. Fields attached via With() are scrubbed at
-// attach time (best effort — values tracked after attach but logged later
-// through such fields bypass scrubbing; call-site fields never do).
-type scrubCore struct {
-	zapcore.Core
-	s Scrubber
-}
-
-func (c *scrubCore) With(fields []zapcore.Field) zapcore.Core {
-	return &scrubCore{Core: c.Core.With(c.scrubFields(fields)), s: c.s}
-}
-
-func (c *scrubCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if c.Enabled(ent.Level) {
-		return ce.AddCore(ent, c)
-	}
-	return ce
-}
-
-func (c *scrubCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
-	if !c.s.HasSecrets() {
-		return c.Core.Write(ent, fields)
-	}
-	ent.Message = c.s.Scrub(ent.Message)
-	return c.Core.Write(ent, c.scrubFields(fields))
-}
-
-func (c *scrubCore) scrubFields(fields []zapcore.Field) []zapcore.Field {
-	if !c.s.HasSecrets() {
-		return fields
-	}
-	out := make([]zapcore.Field, len(fields))
-	copy(out, fields)
-	for i := range out {
-		switch out[i].Type {
-		case zapcore.StringType:
-			out[i].String = c.s.Scrub(out[i].String)
-		case zapcore.ByteStringType:
-			if b, ok := out[i].Interface.([]byte); ok {
-				out[i].Interface = []byte(c.s.Scrub(string(b)))
-			}
-		case zapcore.ErrorType:
-			if err, ok := out[i].Interface.(error); ok {
-				out[i] = zapcore.Field{Key: out[i].Key, Type: zapcore.StringType, String: c.s.Scrub(err.Error())}
-			}
-		}
-	}
-	return out
+	return requestctx.WrapWithScrubber(l, s)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,9 +12,8 @@ import (
 )
 
 type Client struct {
-	db   *badger.DB
-	once sync.Once
-	mu   sync.Mutex
+	db *badger.DB
+	mu sync.Mutex
 }
 
 var client *Client
@@ -52,31 +51,27 @@ func GetClient() (*Client, error) {
 }
 
 func (c *Client) ensureOpen() error {
-	var openErr error
+	_, err := c.dbHandle()
+	return err
+}
 
-	c.once.Do(func() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
-		db, err := openDB()
-		if err != nil {
-			openErr = err
-			return
-		}
-		c.db = db
-	})
-
-	if openErr != nil {
-		return openErr
-	}
-
+// dbHandle returns the open badger DB, opening it if necessary. It takes the
+// client mutex for the whole read-open-store sequence so that concurrent
+// Close/reset (which mutate c.db under the same lock) can never race the field
+// access. Callers must not hold c.mu.
+func (c *Client) dbHandle() (*badger.DB, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if c.db == nil {
-		return errors.New("failed to initialize client")
+		db, err := openDB()
+		if err != nil {
+			return nil, err
+		}
+		c.db = db
 	}
 
-	return nil
+	return c.db, nil
 }
 
 func isDBClosedError(err error) bool {
@@ -88,7 +83,6 @@ func (c *Client) reset() error {
 	defer c.mu.Unlock()
 
 	c.db = nil
-	c.once = sync.Once{}
 
 	db, err := openDB()
 	if err != nil {
@@ -113,7 +107,6 @@ func (c *Client) Close() error {
 
 	err := c.db.Close()
 	c.db = nil
-	c.once = sync.Once{}
 	return err
 }
 
@@ -127,8 +120,8 @@ func WriteToLog(key string, value []Serializable) error {
 		ts := time.Now().UnixNano()
 		k := []byte(fmt.Sprintf("%s:%s:%d", servflowPrefix, strings.Trim(key, ":"), ts))
 
-		_, err = withRetryOnClose(func(c *Client) (struct{}, error) {
-			err := c.db.Update(func(txn *badger.Txn) error {
+		_, err = withRetryOnClose(func(db *badger.DB) (struct{}, error) {
+			err := db.Update(func(txn *badger.Txn) error {
 				return txn.Set(k, b)
 			})
 			return struct{}{}, err
@@ -148,9 +141,9 @@ func GetLogEntriesByPrefix(prefix string, deserializeFunc func([]byte) (any, err
 	}
 	bPrefix := []byte(fmt.Sprintf("%s:%s:", servflowPrefix, prefix))
 
-	return withRetryOnClose(func(c *Client) ([]any, error) {
+	return withRetryOnClose(func(db *badger.DB) ([]any, error) {
 		result := make([]any, 0)
-		err := c.db.View(func(txn *badger.Txn) error {
+		err := db.View(func(txn *badger.Txn) error {
 			opts := badger.DefaultIteratorOptions
 			opts.PrefetchSize = 10
 			it := txn.NewIterator(opts)
@@ -176,7 +169,11 @@ func GetLogEntriesByPrefix(prefix string, deserializeFunc func([]byte) (any, err
 	})
 }
 
-func withRetryOnClose[T any](operation func(*Client) (T, error)) (T, error) {
+// withRetryOnClose runs operation against the currently-open badger DB. The DB
+// handle is snapshotted under the client mutex, so the operation never touches
+// c.db directly and cannot race a concurrent Close/reset. If the DB was closed
+// out from under us mid-operation, it is reopened once and the operation retried.
+func withRetryOnClose[T any](operation func(*badger.DB) (T, error)) (T, error) {
 	var zero T
 
 	c, err := GetClient()
@@ -184,13 +181,22 @@ func withRetryOnClose[T any](operation func(*Client) (T, error)) (T, error) {
 		return zero, err
 	}
 
-	result, err := operation(c)
+	db, err := c.dbHandle()
+	if err != nil {
+		return zero, err
+	}
+
+	result, err := operation(db)
 	if isDBClosedError(err) {
 		if resetErr := c.reset(); resetErr != nil {
 			return zero, resetErr
 		}
 
-		result, err = operation(c)
+		if db, err = c.dbHandle(); err != nil {
+			return zero, err
+		}
+
+		result, err = operation(db)
 	}
 
 	return result, err
@@ -203,8 +209,8 @@ func Set(key string, value string) error {
 
 	k := []byte(fmt.Sprintf("%s:%s:%s", servflowPrefix, kvPrefix, key))
 
-	_, err := withRetryOnClose(func(c *Client) (struct{}, error) {
-		err := c.db.Update(func(txn *badger.Txn) error {
+	_, err := withRetryOnClose(func(db *badger.DB) (struct{}, error) {
+		err := db.Update(func(txn *badger.Txn) error {
 			return txn.Set(k, []byte(value))
 		})
 		return struct{}{}, err
@@ -225,11 +231,11 @@ func Get(key string) (string, bool, error) {
 
 	k := []byte(fmt.Sprintf("%s:%s:%s", servflowPrefix, kvPrefix, key))
 
-	result, err := withRetryOnClose(func(c *Client) (GetResult, error) {
+	result, err := withRetryOnClose(func(db *badger.DB) (GetResult, error) {
 		var value []byte
 		var found bool
 
-		err := c.db.View(func(txn *badger.Txn) error {
+		err := db.View(func(txn *badger.Txn) error {
 			item, err := txn.Get(k)
 			if err != nil {
 				if err == badger.ErrKeyNotFound {

--- a/pkg/tracing/lifecycle_integration_test.go
+++ b/pkg/tracing/lifecycle_integration_test.go
@@ -1,0 +1,88 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// endedByName returns the single ended span with the given SpanName.
+func endedByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	var found sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			require.Nil(t, found, "more than one %q span exported", name)
+			found = s
+		}
+	}
+	require.NotNil(t, found, "no %q span exported", name)
+	return found
+}
+
+// TestLifecycleBinding_RootEndsAfterFlow proves the rc lifecycle owns the root
+// span end: a root bound via StartHTTPEntry stays un-ended after Done while a
+// child flow is open, then ends exactly once when the flow drains — covering
+// request-wide attr stamping on the root only (not children), token totals
+// stamped at end including late tokens, and root ⊇ child in time.
+func TestLifecycleBinding_RootEndsAfterFlow(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	tracer = otel.Tracer("servflow-test")
+
+	// host-supplied request-wide attribute, like pro's sf.agent.
+	ctx, rc := requestctx.Start(context.Background(), requestctx.Options{
+		ID:             "req-123",
+		SpanAttributes: []attribute.KeyValue{attribute.String("sf.agent", "AcctBot")},
+	})
+	ctx, _ = StartHTTPEntry(ctx, "My Workflow", "wf-id")
+
+	// a child action span within the request.
+	_, childSpan := StartAction(ctx, "a1", "greet", "stub")
+	childSpan.End()
+
+	// child already ended, root not yet (main flow still running).
+	assert.Len(t, sr.Ended(), 1, "only the child span has ended")
+
+	// a background dispatch chain registers a flow.
+	endFlow := rc.BeginFlow("dispatch:x")
+
+	// main flow completes (response written).
+	rc.Done()
+	assert.Len(t, sr.Ended(), 1, "root must not end while the flow is open")
+
+	// background work adds tokens AFTER the response.
+	rc.AddTokenUsage(100, 50)
+
+	// flow drains → root ends now.
+	endFlow()
+
+	ended := sr.Ended()
+	root := endedByName(t, ended, "HTTP Entry")
+	child := endedByName(t, ended, "Action")
+
+	rootAttrs := attrMap(root.Attributes())
+	// Request id + host attr live on the ROOT span only.
+	assert.Equal(t, "req-123", rootAttrs[requestctx.AttrRequestID])
+	assert.Equal(t, "AcctBot", rootAttrs["sf.agent"])
+	// Child spans do NOT carry the request-wide attributes.
+	childAttrs := attrMap(child.Attributes())
+	assert.NotContains(t, childAttrs, requestctx.AttrRequestID)
+	assert.NotContains(t, childAttrs, "sf.agent")
+
+	// Late tokens landed on the root (stamped by the beforeEnd hook).
+	assert.Equal(t, int64(150), rootAttrs[AttrUsageTotal])
+	assert.Equal(t, int64(100), rootAttrs[AttrUsageInput])
+	assert.Equal(t, int64(50), rootAttrs[AttrUsageOutput])
+
+	// Root temporally covers the child (deferred End = true total).
+	assert.GreaterOrEqual(t, root.EndTime().UnixNano(), child.EndTime().UnixNano(),
+		"root EndTime >= child EndTime")
+}

--- a/pkg/tracing/spans.go
+++ b/pkg/tracing/spans.go
@@ -67,6 +67,8 @@ const (
 	AttrToolName     = "sf.tool_name"
 	AttrToolType     = "sf.tool_type"   // mcp | workflow
 	AttrToolParams   = "sf.tool_params" // JSON of model-supplied tool-call arguments (sensitive keys redacted, size-capped)
+
+	AttrRequestID = requestctx.AttrRequestID // stamped on the root span via the rc
 )
 
 // start creates a span with a low-cardinality name and always attaches the
@@ -85,6 +87,19 @@ func start(ctx context.Context, spanName, display string, attrs ...attribute.Key
 	return ctx, span
 }
 
+// bindRoot hands a root entry span to the request lifecycle: the
+// RequestContext defers its End until the main flow AND all child flows
+// complete, and stamps the request token totals right before ending. It also
+// stamps the request-wide attributes (sf.request_id, host attrs like sf.agent)
+// on the root span only — child spans do not carry them. Without an rc in ctx
+// (tests, tracing-disabled callers) the caller keeps manual End responsibility.
+func bindRoot(ctx context.Context, span trace.Span) {
+	if rc, ok := requestctx.FromContext(ctx); ok {
+		span.SetAttributes(rc.SpanAttributes()...)
+		rc.BindRootSpan(span, func(s trace.Span) { stampRequestTokens(rc, s) })
+	}
+}
+
 // rootDisplay picks the friendly label for a workflow root span: the
 // human-readable name when set, otherwise the stable config id.
 func rootDisplay(name, id string) string {
@@ -98,9 +113,11 @@ func rootDisplay(name, id string) string {
 // friendly display name and id its stable config id; both identify which
 // workflow the trace belongs to.
 func StartHTTPEntry(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	return start(ctx, "HTTP Entry", rootDisplay(name, id),
+	ctx, span := start(ctx, "HTTP Entry", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
+	bindRoot(ctx, span)
+	return ctx, span
 }
 
 // SetHTTPStatus records the final HTTP status code on the entry span and, per
@@ -149,25 +166,31 @@ func StartResponse(ctx context.Context, id, name string) (context.Context, trace
 // StartWorkflowExecute spans a workflow invoked through a trigger (e.g. callworkflow).
 // name is the workflow's friendly display name and id its stable config id.
 func StartWorkflowExecute(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	return start(ctx, "Workflow Execute", rootDisplay(name, id),
+	ctx, span := start(ctx, "Workflow Execute", rootDisplay(name, id),
 		attribute.String(AttrStepType, "trigger"),
 		attribute.String(AttrWorkflow, id))
+	bindRoot(ctx, span)
+	return ctx, span
 }
 
 // StartScheduledExecution spans a scheduled (cron) workflow run.
 // name is the workflow's friendly display name and id its stable config id.
 func StartScheduledExecution(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	return start(ctx, "Scheduled Execution", rootDisplay(name, id),
+	ctx, span := start(ctx, "Scheduled Execution", rootDisplay(name, id),
 		attribute.String(AttrStepType, "scheduled"),
 		attribute.String(AttrWorkflow, id))
+	bindRoot(ctx, span)
+	return ctx, span
 }
 
 // StartDashboardRun spans a manual workflow run triggered from the builder dashboard.
 // name is the workflow's friendly display name and id its stable config id.
 func StartDashboardRun(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	return start(ctx, "Dashboard Run", rootDisplay(name, id),
+	ctx, span := start(ctx, "Dashboard Run", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
+	bindRoot(ctx, span)
+	return ctx, span
 }
 
 // StartAgentInvoke spans a whole agent-action run (the GenAI invoke_agent
@@ -187,12 +210,14 @@ func StartAgentInvoke(ctx context.Context, name string) (context.Context, trace.
 // StartMCPTool spans the invocation of an MCP tool. Carries both the sf.* tool
 // keys and the GenAI execute_tool attributes.
 func StartMCPTool(ctx context.Context, name string) (context.Context, trace.Span) {
-	return start(ctx, "MCP Tool", name,
+	ctx, span := start(ctx, "MCP Tool", name,
 		attribute.String(AttrToolName, name),
 		attribute.String(AttrToolType, "mcp"),
 		attribute.String(AttrGenAIOperation, opExecuteTool),
 		attribute.String(AttrGenAIToolName, name),
 		attribute.String(AttrGenAIToolType, "mcp"))
+	bindRoot(ctx, span)
+	return ctx, span
 }
 
 // StartAgentTool spans the invocation of an agent workflow tool. Carries both

--- a/pkg/tracing/tokens.go
+++ b/pkg/tracing/tokens.go
@@ -31,9 +31,18 @@ func addTokens(ctx context.Context, input, output int64) {
 	}
 }
 
-// SetRequestTokens attaches the request-level token totals to span. Call just
-// before ending a root span. No-op when the span is nil or ctx carries no
-// request context.
+// stampRequestTokens writes the request-level token totals onto span.
+func stampRequestTokens(rc *requestctx.RequestContext, span trace.Span) {
+	in, out := rc.TokenUsage()
+	span.SetAttributes(
+		attribute.Int64(AttrUsageInput, in),
+		attribute.Int64(AttrUsageOutput, out),
+		attribute.Int64(AttrUsageTotal, in+out),
+	)
+}
+
+// Deprecated: root spans stamp token totals via the RequestContext lifecycle
+// (BindRootSpan); no new call sites.
 func SetRequestTokens(ctx context.Context, span trace.Span) {
 	if span == nil {
 		return
@@ -42,10 +51,5 @@ func SetRequestTokens(ctx context.Context, span trace.Span) {
 	if !ok {
 		return
 	}
-	in, out := rc.TokenUsage()
-	span.SetAttributes(
-		attribute.Int64(AttrUsageInput, in),
-		attribute.Int64(AttrUsageOutput, out),
-		attribute.Int64(AttrUsageTotal, in+out),
-	)
+	stampRequestTokens(rc, span)
 }


### PR DESCRIPTION
Make requestctx.Start the single request entry point and give the RequestContext ownership of the request's lifetime-scoped facilities: logger, span attributes, template funcs, secrets and the root-span lifecycle.

- Move the ctx-logger primitives + scrub core into requestctx; pkg/logging delegates with its public API unchanged.
- lifecycle.go: Start/Done/BeginFlow/OnComplete + BindRootSpan. The root span's End is deferred until the main flow AND every child flow (dispatch chains) drain, so the root Duration is the request's true total time. Stamps sf.request_id on every span and sf.response_time_ms on the root.
- tracing: append rc.SpanAttributes() to every span; the 5 root constructors bind their span to the rc lifecycle; token totals are stamped just before End.
- dispatch chains register a flow so background work stays inside the root envelope.
- HTTP + MCP handlers open the request via Start; the middleware is slimmed to process-level concerns only.