### PR TITLE
track secrets through template transforms via taint propagation

### DIFF
--- a/pkg/engine/requestctx/secrets.go
+++ b/pkg/engine/requestctx/secrets.go
@@ -1,6 +1,7 @@
 package requestctx
 
 import (
+	"sort"
 	"strings"
 	"sync"
 )
@@ -21,6 +22,11 @@ const (
 	// replacing very short strings (e.g. "a") would corrupt unrelated output
 	// far more than it protects, so such values are not tracked.
 	minTrackedValueLen = 4
+
+	// minTrackedLineLen is the threshold for tracking individual lines of a
+	// multi-line secret. Higher than minTrackedValueLen because a single line
+	// is likelier to collide with unrelated output.
+	minTrackedLineLen = 16
 )
 
 // secretTable records the secret values resolved during one request AND every
@@ -37,28 +43,66 @@ func newSecretTable() *secretTable {
 }
 
 // track records a resolved secret value so scrubbers can mask it wherever it
-// surfaces for the rest of the request.
+// surfaces for the rest of the request. Transformed copies produced by
+// template functions (escaped, url-encoded, ...) are tracked automatically by
+// the taint wrapper (see taint.go), which calls track with the transform's
+// real output — no transform prediction here.
+//
+// For multi-line secrets (e.g. PEM keys) each substantial line is tracked too:
+// lines are verbatim substrings of the value, so a copy whose newlines are
+// re-encoded or reflowed by an external system is still masked.
 func (t *secretTable) track(name, value string) {
 	if len(value) < minTrackedValueLen {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.values[value] = name
-	t.mu.Unlock()
+	if strings.Contains(value, "\n") {
+		for _, line := range strings.Split(value, "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) >= minTrackedLineLen {
+				t.values[line] = name
+			}
+		}
+	}
+}
+
+// matchName reports the name of a tracked secret whose value appears in s.
+// Used by the taint wrapper to decide whether a transform's output is derived
+// from a secret.
+func (t *secretTable) matchName(s string) (string, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if len(t.values) == 0 || s == "" {
+		return "", false
+	}
+	for v, name := range t.values {
+		if strings.Contains(s, v) {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // scrub replaces any tracked secret value found in s with «sf:name». Exact
 // match against the (tiny) tracked set; a no-op for requests that resolved no
-// secrets.
+// secrets. Longer entries replace first so a full multi-line value is masked
+// as one marker rather than line by line.
 func (t *secretTable) scrub(s string) string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if len(t.values) == 0 || s == "" {
 		return s
 	}
-	for v, name := range t.values {
+	keys := make([]string, 0, len(t.values))
+	for v := range t.values {
+		keys = append(keys, v)
+	}
+	sort.Slice(keys, func(i, j int) bool { return len(keys[i]) > len(keys[j]) })
+	for _, v := range keys {
 		if strings.Contains(s, v) {
-			s = strings.ReplaceAll(s, v, scrubMarkerPrefix+name+scrubMarkerSuffix)
+			s = strings.ReplaceAll(s, v, scrubMarkerPrefix+t.values[v]+scrubMarkerSuffix)
 		}
 	}
 	return s

--- a/pkg/engine/requestctx/secrets_test.go
+++ b/pkg/engine/requestctx/secrets_test.go
@@ -176,3 +176,25 @@ func TestSecretTableConcurrency(t *testing.T) {
 	assert.True(t, rc.HasSecrets())
 	assert.NotContains(t, rc.Scrub("supersecretvalue"), "supersecretvalue")
 }
+
+// TestFileKeyMaterialTracked verifies {{ file }} tracks private-key contents
+// (the github-ci plugin delivers the App PEM as a workspace file), while
+// ordinary files are left as workflow data.
+func TestFileKeyMaterialTracked(t *testing.T) {
+	rc, ctx := newTestRC(t)
+	pem := "-----BEGIN RSA PRIVATE KEY-----\nFileDeliveredKeyMaterialLine0123456789abcdef\n-----END RSA PRIVATE KEY-----"
+	rc.SetWorkspace(&mockWorkspace{files: map[string][]byte{"app.pem": []byte(pem)}})
+
+	out, err := rc.Resolve(ctx, `{{ file "app.pem" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, pem, out)
+	assert.True(t, rc.HasSecrets())
+	assert.NotContains(t, rc.Scrub("leaked: FileDeliveredKeyMaterialLine0123456789abcdef"), "KeyMaterial")
+
+	rc2 := NewRequestContext("t2")
+	rc2.SetWorkspace(&mockWorkspace{files: map[string][]byte{"notes.txt": []byte("hello world, plain file")}})
+	ctx2 := WithAggregationContext(context.Background(), rc2)
+	_, err = rc2.Resolve(ctx2, `{{ file "notes.txt" }}`)
+	require.NoError(t, err)
+	assert.False(t, rc2.HasSecrets())
+}

--- a/pkg/engine/requestctx/taint.go
+++ b/pkg/engine/requestctx/taint.go
@@ -1,0 +1,98 @@
+package requestctx
+
+import (
+	"fmt"
+	"reflect"
+	"text/template"
+)
+
+// Taint tracking propagates secret tracking through template transforms.
+//
+// A secret resolves to its real value (so `escape`, `urlquery`, `hash`, etc.
+// behave normally), and the scrubber masks tracked values by exact match. The
+// gap that leaves: a transform produces a NEW string the scrubber has never
+// seen — `escape (secret "x")` yields an escaped copy that no longer matches
+// the raw value, so it slips into logs/traces.
+//
+// Rather than predict what each transform produces, we observe it: every
+// template function is wrapped so that whenever it runs with an argument
+// containing a tracked secret, its string result is tracked too. This covers
+// every transform — built-in, request-scoped, or added by an entry handler —
+// and any chain of them, because each tainted output re-taints the next call's
+// input. Only transforms performed OUTSIDE the engine (e.g. an API base64-ing
+// a token before echoing it) remain invisible, which is unavoidable.
+
+// taintWrap returns fn wrapped to track its output when fed a tracked secret.
+// Functions that cannot return a string as their first result are returned
+// unchanged (they can't leak a string), as are non-functions.
+func (rc *RequestContext) taintWrap(fn interface{}) interface{} {
+	v := reflect.ValueOf(fn)
+	if !v.IsValid() || v.Kind() != reflect.Func {
+		return fn
+	}
+	t := v.Type()
+	if t.NumOut() == 0 || t.Out(0).Kind() != reflect.String {
+		return fn
+	}
+	variadic := t.IsVariadic()
+	return reflect.MakeFunc(t, func(args []reflect.Value) []reflect.Value {
+		var out []reflect.Value
+		if variadic {
+			// MakeFunc presents a variadic function's trailing arguments as a
+			// single slice in the final position, which is exactly the form
+			// CallSlice forwards.
+			out = v.CallSlice(args)
+		} else {
+			out = v.Call(args)
+		}
+		// Fast path: no secrets resolved yet → nothing to propagate.
+		if rc.secrets.hasSecrets() {
+			if name, ok := taintName(rc.secrets, args); ok {
+				if s := out[0].String(); len(s) >= minTrackedValueLen {
+					rc.secrets.track(name, s)
+				}
+			}
+		}
+		return out
+	}).Interface()
+}
+
+// taintName reports the secret name if any argument's string form contains a
+// tracked secret value. Matching on substring (not data-flow provenance) is
+// what makes chains and composites work: a formatted or concatenated argument
+// that embeds a secret still matches.
+func taintName(t *secretTable, args []reflect.Value) (string, bool) {
+	for _, a := range args {
+		if !a.IsValid() || !a.CanInterface() {
+			continue
+		}
+		var s string
+		switch x := a.Interface().(type) {
+		case string:
+			s = x
+		default:
+			s = fmt.Sprintf("%v", x)
+		}
+		if name, ok := t.matchName(s); ok {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// taintableBuiltins returns thin stand-ins for the string-producing
+// text/template built-ins. Built-ins are not registered via FuncMap, so they
+// would bypass taint wrapping; a FuncMap entry of the same name overrides the
+// built-in. Each delegates to the exact stdlib function the built-in uses, so
+// behaviour is identical — only the taint wrapper is added. Comparison
+// built-ins (eq, len, index, ...) return non-strings and need no shadow.
+func taintableBuiltins() template.FuncMap {
+	return template.FuncMap{
+		"printf":   fmt.Sprintf,
+		"print":    fmt.Sprint,
+		"println":  fmt.Sprintln,
+		"html":     template.HTMLEscaper,
+		"js":       template.JSEscaper,
+		"urlquery": template.URLQueryEscaper,
+	}
+}

--- a/pkg/engine/requestctx/taint_test.go
+++ b/pkg/engine/requestctx/taint_test.go
@@ -1,0 +1,155 @@
+package requestctx
+
+import (
+	"testing"
+
+	"github.com/Servflow/servflow/pkg/engine/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTaintEscapeTracksTransformedSecret is the core case: `escape` produces a
+// new string that no longer equals the raw secret, and taint tracking must
+// track that output so the scrubber catches it.
+func TestTaintEscapeTracksTransformedSecret(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("QUOTED", `va"lue-long-enough`)
+
+	rc, ctx := newTestRC(t)
+	out, err := rc.Resolve(ctx, `{{ escape (secret "QUOTED") }}`)
+	require.NoError(t, err)
+	assert.Equal(t, `va\"lue-long-enough`, out) // real transform applied
+
+	// The escaped form is tracked even though it differs from the raw value.
+	assert.Equal(t, scrubMarkerPrefix+"QUOTED"+scrubMarkerSuffix, rc.Scrub(`va\"lue-long-enough`))
+	// The raw form is still tracked too.
+	assert.Equal(t, scrubMarkerPrefix+"QUOTED"+scrubMarkerSuffix, rc.Scrub(`va"lue-long-enough`))
+}
+
+// TestMultilinePEMScrubbedInEscapedForm reproduces the github_token leak: a V1
+// JSON config embeds the PEM via {{ escape (secret ...) }}, so the resolved
+// config (and the sf.config span attribute) holds the ESCAPED image of the PEM
+// — \n as two chars — which taint tracking must catch.
+func TestMultilinePEMScrubbedInEscapedForm(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	pem := "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA2mFyUnrightlyLongBase64LineGoesHere01\nQZzz9SecondBase64LineWithMoreKeyMaterialHere567890ab\n-----END RSA PRIVATE KEY-----"
+	t.Setenv("GH_PEM", pem)
+
+	rc, ctx := newTestRC(t)
+	resolvedCfg, err := rc.Resolve(ctx, `{"pem":"{{ escape (secret "GH_PEM") }}","client_id":"abc"}`)
+	require.NoError(t, err)
+	require.Contains(t, resolvedCfg, `\n`, "escape should have encoded the newlines")
+
+	scrubbed := rc.Scrub(resolvedCfg)
+	assert.NotContains(t, scrubbed, "MIIEowIBAAKCAQEA2mFyUnrightlyLongBase64LineGoesHere01")
+	assert.NotContains(t, scrubbed, "QZzz9SecondBase64LineWithMoreKeyMaterialHere567890ab")
+	assert.Contains(t, scrubbed, `"client_id":"abc"`, "non-secret config must survive")
+
+	// Raw form masked as a single marker (longest-first replacement).
+	assert.Equal(t, scrubMarkerPrefix+"GH_PEM"+scrubMarkerSuffix, rc.Scrub(pem))
+	// Reflowed fragments (individual lines) masked too (external-reflow backstop).
+	assert.NotContains(t, rc.Scrub("saw MIIEowIBAAKCAQEA2mFyUnrightlyLongBase64LineGoesHere01 in output"), "MIIEow")
+}
+
+// TestTaintUrlqueryBuiltin proves a shadowed built-in (urlquery) routes through
+// taint tracking — a live leak vector for secrets in query params.
+func TestTaintUrlqueryBuiltin(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("TOK", "s p a c e/secret+value")
+
+	rc, ctx := newTestRC(t)
+	out, err := rc.Resolve(ctx, `https://x?t={{ urlquery (secret "TOK") }}`)
+	require.NoError(t, err)
+	require.Contains(t, out, "%2F", "urlquery should url-encode the value")
+
+	// The url-encoded form is tracked.
+	assert.NotContains(t, rc.Scrub(out), "secret%2Bvalue")
+	assert.Contains(t, rc.Scrub(out), scrubMarkerPrefix+"TOK"+scrubMarkerSuffix)
+}
+
+// TestTaintPrintfComposite proves a composite output (printf embedding a
+// secret) is tracked, and variadic funcs are wrapped correctly.
+func TestTaintPrintfComposite(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("APIKEY", "supersecretapikey")
+
+	rc, ctx := newTestRC(t)
+	out, err := rc.Resolve(ctx, `{{ printf "Authorization: Bearer %s" (secret "APIKEY") }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "Authorization: Bearer supersecretapikey", out)
+
+	assert.NotContains(t, rc.Scrub(out), "supersecretapikey")
+}
+
+// TestTaintChain proves nested transforms compose: escape of escape.
+func TestTaintChain(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("MULTI", `a"b"c-long-enough-value`)
+
+	rc, ctx := newTestRC(t)
+	out, err := rc.Resolve(ctx, `{{ escape (escape (secret "MULTI")) }}`)
+	require.NoError(t, err)
+
+	// Whatever the double-escaped form is, it's tracked.
+	assert.Equal(t, scrubMarkerPrefix+"MULTI"+scrubMarkerSuffix, rc.Scrub(out))
+}
+
+// TestTaintHashTracksDigest proves a one-way transform (hash) tracks its digest
+// so digests of secrets don't leak either.
+func TestTaintHashTracksDigest(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("PW", "supersecretpassword")
+
+	rc, ctx := newTestRC(t)
+	out, err := rc.Resolve(ctx, `{{ hash (secret "PW") }}`)
+	require.NoError(t, err)
+	require.NotEqual(t, "supersecretpassword", out)
+
+	assert.Equal(t, scrubMarkerPrefix+"PW"+scrubMarkerSuffix, rc.Scrub(out))
+}
+
+// TestTaintDoesNotTrackUntransformedData proves ordinary (non-secret) data
+// passing through a transform is NOT tracked — no over-masking.
+func TestTaintDoesNotTrackUntransformedData(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("TOK", "supersecretvalue")
+
+	rc, ctx := newTestRC(t)
+	// Resolve a secret so the table is non-empty (HasSecrets true).
+	_, err := rc.Resolve(ctx, `{{ secret "TOK" }}`)
+	require.NoError(t, err)
+
+	// escape ordinary data — its output must NOT be tracked.
+	out, err := rc.Resolve(ctx, `{{ escape "just a normal config value" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, out, rc.Scrub(out), "non-secret transform output must not be masked")
+}
+
+// TestTaintCustomRequestFunc proves functions added at request time (e.g. by an
+// entry handler) are wrapped too — the user's specific concern.
+func TestTaintCustomRequestFunc(t *testing.T) {
+	secrets.Reset()
+	t.Cleanup(secrets.Reset)
+	t.Setenv("TOK", "supersecretvalue")
+
+	rc, ctx := newTestRC(t)
+	// A custom transform registered after the context exists, as an entry
+	// handler or trigger engine would do.
+	rc.AddRequestTemplateFunctions(map[string]any{
+		"wrapbrackets": func(s string) string { return "[[" + s + "]]" },
+	}, true)
+
+	out, err := rc.Resolve(ctx, `{{ wrapbrackets (secret "TOK") }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "[[supersecretvalue]]", out)
+
+	// The custom func's output (containing the secret) is tracked.
+	assert.NotContains(t, rc.Scrub(out), "supersecretvalue")
+}

--- a/pkg/engine/requestctx/templates.go
+++ b/pkg/engine/requestctx/templates.go
@@ -115,6 +115,19 @@ func (rc *RequestContext) getFuncMap(funcMap template.FuncMap) template.FuncMap 
 	for k, v := range funcMap {
 		m[k] = v
 	}
+	// Route the string-producing text/template built-ins through the FuncMap
+	// (they bypass it otherwise) unless the caller already overrode them.
+	for k, v := range taintableBuiltins() {
+		if _, exists := m[k]; !exists {
+			m[k] = v
+		}
+	}
+	// Taint-wrap every function so a transform applied to a secret keeps the
+	// secret tracked for scrubbing — whoever registered the function and
+	// however deep the transform chain. See taint.go.
+	for k, v := range m {
+		m[k] = rc.taintWrap(v)
+	}
 	return m
 }
 
@@ -132,13 +145,6 @@ func stringEscape(s interface{}) string {
 
 func now() string {
 	return time.Now().Format("2006-01-02 15:04:05")
-}
-
-// secret is the base (host-side, no RequestContext) template func used by
-// paths with no request in flight (config load, CLI). Request-scoped templates
-// use tmplFuncSecret, which additionally tracks the value for scrubbing.
-func secret(key string) string {
-	return secrets.FetchSecret(key)
 }
 
 // tmplFuncSecret is the request-scoped `secret` template function. It returns
@@ -358,5 +364,20 @@ func (rc *RequestContext) tmplFuncFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(data), nil
+	content := string(data)
+	// Private-key material (e.g. a GitHub App PEM delivered as a workspace
+	// file) is tracked for scrubbing like a {{ secret }} value. The taint
+	// wrapper can't cover it: it keys off function arguments, and this func's
+	// argument is a path, not the secret. Deliberately narrow — public certs
+	// and ordinary files are workflow data, and over-tracking would scrub
+	// legitimate content out of action outputs.
+	if looksLikeKeyMaterial(content) {
+		rc.secrets.track("file:"+path, content)
+	}
+	return content, nil
+}
+
+// looksLikeKeyMaterial reports whether file contents are a private key.
+func looksLikeKeyMaterial(s string) bool {
+	return strings.Contains(s, "PRIVATE KEY-----")
 }


### PR DESCRIPTION
The scrubber masks secret values by exact match, so a value transformed by a template function (escape, urlquery, printf, hash, ...) produced a new string it never saw and leaked — a GitHub App PEM embedded in a V1 JSON config via {{ escape (secret ...) }} appeared in full on the sf.config span.

Rather than predict each transform's output, observe it: every request template function is wrapped so that when it runs with an argument containing a tracked secret, its string result is tracked too. Covers built-ins, request-scoped funcs, entry-handler funcs, and any chain of them, since each tainted output re-taints the next call's input. The string-producing text/template built-ins (printf, print, println, html, js, urlquery) are shadowed as FuncMap entries so they route through the wrapper instead of bypassing it.

- taint.go: taintWrap (reflect.MakeFunc, variadic-aware), taintName, taintableBuiltins
- secretTable.matchName; multi-line line tracking + longest-first scrub (external-reflow backstop)
- {{ file }} tracks private-key material (its argument is a path, so the taint wrapper can't see the contents)

Only transforms performed outside the engine remain invisible (e.g. an API base64-ing a token before echoing it) — information-theoretically unavoidable.