### PR TITLE
requestctx: centralize the agent conversation thread

### DIFF
--- a/examples/db-agent/configs/db-agent.yaml
+++ b/examples/db-agent/configs/db-agent.yaml
@@ -54,8 +54,13 @@ responses:
     code: 200
     responseObject:
       fields:
+        # An agent action produces no output variable: everything it says goes to
+        # the request conversation instead, so there is no
+        # {{ .variable_actions_agent }} to read here. Returning the agent's answer
+        # to the caller is the job of an output handler, which reads the thread —
+        # until that lands this endpoint responds with an empty body.
         response:
-          value: "{{ .variable_actions_agent }}"
+          value: ""
 
   "400":
     code: 400

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,7 +4,6 @@ package agent
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,8 +17,6 @@ import (
 
 //go:embed new_instructions.md
 var instructions []byte
-
-const conversationStoragePrefix = "agent_conversation_"
 
 type ToolManager interface {
 	CallTool(ctx context.Context, toolName string, params map[string]any) ([]mcp.Content, error)
@@ -43,7 +40,7 @@ type Session struct {
 	toolManager           ToolManager
 	llm                   LLmProvider
 	messages              []any
-	conversationID        string
+	conversation          *requestctx.Conversation
 	returnOnlyLastMessage bool
 	customInstructions    string
 	llmResponses          []LLMResponse
@@ -58,40 +55,20 @@ func WithToolManager(toolManager ToolManager) Option {
 	}
 }
 
-func WithConversationID(ctx context.Context, id string) Option {
+// WithConversation binds the session to the request's shared conversation
+// thread. The session seeds its working context with the thread so far (so it
+// sees what earlier agents in the run said) and appends every message it
+// produces back to the thread. A nil conversation is a no-op — the session
+// keeps a purely local, unshared history.
+func WithConversation(conv *requestctx.Conversation) Option {
 	return func(a *Session) error {
-		if id == "" {
-			return fmt.Errorf("conversationID can not be empty")
+		a.conversation = conv
+		if conv == nil {
+			return nil
 		}
-		a.conversationID = id
-		messages, err := storage.GetLogEntriesByPrefix(conversationStoragePrefix+id, func(data []byte) (any, error) {
-			var msg Message
-			err := json.Unmarshal(data, &msg)
-			if err != nil {
-				return nil, err
-			}
-			switch msg.Type {
-			case MessageTypeText:
-				var contentMessage MessageTypeContent
-				err = json.Unmarshal(data, &contentMessage)
-				return contentMessage, err
-			case MessageTypeToolResponse:
-				var toolResponse MessageToolCallResponse
-				err = json.Unmarshal(data, &toolResponse)
-				return toolResponse, err
-			case MessageTypeToolCall:
-				var toolCall MessageToolCall
-				err = json.Unmarshal(data, &toolCall)
-				return toolCall, err
-			default:
-				logging.FromContext(ctx).Warn("invalid type in log storage", zap.Int("type", int(msg.Type)))
-			}
-			return nil, nil
-		})
-		if err != nil {
-			return err
+		for _, m := range conv.Messages() {
+			a.messages = append(a.messages, m)
 		}
-		a.messages = append(a.messages, messages...)
 		return nil
 	}
 }
@@ -303,14 +280,6 @@ func createToolResponseFromMCPContent(callID string, contentList []mcp.Content) 
 // TODO: think of context management strategy for image responses, they can cause bloat
 
 func (a *Session) addToMessages(logger *zap.Logger, message any, output chan agentOutput) {
-	storageKey := ""
-	if a.conversationID != "" {
-		storageKey = conversationStoragePrefix + a.conversationID
-	}
-
-	var (
-		serializable storage.Serializable
-	)
 	switch message := message.(type) {
 	case MessageTypeContent:
 		a.messages = append(a.messages, message)
@@ -319,21 +288,22 @@ func (a *Session) addToMessages(logger *zap.Logger, message any, output chan age
 				response: message.Content,
 			}
 		}
-
-		serializable = &message
 	case MessageToolCall:
 		a.messages = append(a.messages, message)
-		serializable = &message
 	case MessageToolCallResponse:
 		a.messages = append(a.messages, message)
-		serializable = &message
 	default:
 		logger.Warn("received message of unknown type", zap.Any("message", message))
+		return
 	}
 
-	if storageKey != "" {
-		if err := storage.WriteToLog(storageKey, []storage.Serializable{serializable}); err != nil {
-			logger.Error("failed to write serializable message", zap.Error(err))
+	// Contribute the message to the request's shared conversation thread so
+	// other agents in the run — and, when persistence is enabled, later runs —
+	// can see it. The concrete message types satisfy ConversationMessage via
+	// value receivers.
+	if a.conversation != nil {
+		if cm, ok := message.(ConversationMessage); ok {
+			a.conversation.Append(cm)
 		}
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -37,13 +37,12 @@ var (
 )
 
 type Session struct {
-	toolManager           ToolManager
-	llm                   LLmProvider
-	messages              []any
-	conversation          *requestctx.Conversation
-	returnOnlyLastMessage bool
-	customInstructions    string
-	llmResponses          []LLMResponse
+	toolManager        ToolManager
+	llm                LLmProvider
+	messages           []any
+	conversation       *requestctx.Conversation
+	customInstructions string
+	llmResponses       []LLMResponse
 }
 
 type Option func(*Session) error
@@ -69,13 +68,6 @@ func WithConversation(conv *requestctx.Conversation) Option {
 		for _, m := range conv.Messages() {
 			a.messages = append(a.messages, m)
 		}
-		return nil
-	}
-}
-
-func WithReturnOnlyLastMessage() Option {
-	return func(a *Session) error {
-		a.returnOnlyLastMessage = true
 		return nil
 	}
 }
@@ -109,6 +101,10 @@ type agentOutput struct {
 	response string
 }
 
+// Query runs the agent loop for a turn. Every message produced along the way is
+// appended to the session's conversation, which is where an agent's output is
+// consumed from; the returned string is the concatenated assistant text, kept
+// for callers that want the reply inline (the agent action discards it).
 func (a *Session) Query(ctx context.Context, query string, file *requestctx.FileValue) (string, error) {
 	logger := logging.WithContextEnriched(ctx).With(zap.String("module", "agent"))
 	if query != "" || file != nil {
@@ -120,27 +116,16 @@ func (a *Session) Query(ctx context.Context, query string, file *requestctx.File
 		}, nil)
 	}
 
-	var (
-		strBuilder  strings.Builder
-		lastMessage string
-	)
+	var strBuilder strings.Builder
 	respChan := a.startLoop(ctx)
 	for r := range respChan {
 		if r.err != nil {
 			return "", r.err
 		}
-		if a.returnOnlyLastMessage {
-			lastMessage = r.response
-		} else {
-			strBuilder.WriteString(r.response)
-			strBuilder.WriteString("\n")
-		}
+		strBuilder.WriteString(r.response)
+		strBuilder.WriteString("\n")
 	}
-	if a.returnOnlyLastMessage {
-		return lastMessage, nil
-	} else {
-		return strBuilder.String(), nil
-	}
+	return strBuilder.String(), nil
 }
 
 // GetMetadata returns the metadata collected during the session

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -308,6 +308,89 @@ func TestOrchestrator_ToolErrorWithLLMWrapup(t *testing.T) {
 	assert.Contains(t, result, "I'm unable to complete the weather request due to an error")
 }
 
+// TestSession_AgentsInSameRequestShareConversation proves the property the whole
+// centralisation rests on: two agents running in the SAME request context get
+// the same conversation thread, so what one writes the next one reads. Unlike
+// TestSession_ConversationThreadSharing (which shares a Conversation built
+// directly), this sources the thread from the request context exactly as the
+// agent action does — requestctx.Start → rc.Conversation().
+func TestSession_AgentsInSameRequestShareConversation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, rc := requestctx.Start(context.Background(), requestctx.Options{})
+	defer rc.Done()
+
+	// Every agent action resolves the thread the same way; it must be one object.
+	conv := rc.Conversation()
+	require.NotNil(t, conv, "request context must carry a conversation")
+	require.Same(t, conv, rc.Conversation(), "each agent must resolve the same thread")
+
+	// Agent 1 runs and contributes to the thread.
+	firstLLM := NewMockLLmProvider(ctrl)
+	firstTools := NewMockToolManager(ctrl)
+	firstTools.EXPECT().ToolList(gomock.Any()).Return(nil).AnyTimes()
+	firstLLM.EXPECT().ProvideResponse(gomock.Any(), gomock.Any()).
+		Return(LLMResponse{Content: []ContentResponse{{Text: "agent one reporting"}}}, nil)
+
+	agentOne, err := NewSession("first agent", firstLLM,
+		WithToolManager(firstTools),
+		WithConversation(rc.Conversation()))
+	require.NoError(t, err)
+	_, err = agentOne.Query(ctx, "what did you find?", nil)
+	require.NoError(t, err)
+
+	// Agent 2 starts later in the same request: it must SEE agent 1's exchange
+	// rather than beginning blank.
+	secondLLM := NewMockLLmProvider(ctrl)
+	secondTools := NewMockToolManager(ctrl)
+	secondTools.EXPECT().ToolList(gomock.Any()).Return(nil).AnyTimes()
+	secondLLM.EXPECT().ProvideResponse(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, req LLMRequest) {
+			// assert, never require: this runs on the session's internal goroutine,
+			// where require's FailNow would kill the goroutine without closing the
+			// response channel — hanging the test instead of failing it.
+			if !assert.Len(t, req.Messages, 3) {
+				return
+			}
+			// agent 1's user turn + agent 1's answer + agent 2's own new query.
+			if seeded, ok := req.Messages[0].(MessageTypeContent); assert.True(t, ok,
+				"seeded message lost its concrete type: %T", req.Messages[0]) {
+				assert.Equal(t, RoleTypeUser, seeded.Role)
+				assert.Equal(t, "what did you find?", seeded.Content)
+			}
+			if answer, ok := req.Messages[1].(MessageTypeContent); assert.True(t, ok) {
+				assert.Equal(t, RoleTypeAssistant, answer.Role)
+				assert.Equal(t, "agent one reporting", answer.Content)
+			}
+		}).
+		Return(LLMResponse{Content: []ContentResponse{{Text: "agent two building on that"}}}, nil)
+
+	agentTwo, err := NewSession("second agent", secondLLM,
+		WithToolManager(secondTools),
+		WithConversation(rc.Conversation()))
+	require.NoError(t, err)
+	assert.Len(t, agentTwo.messages, 2, "agent two should be seeded with agent one's exchange")
+
+	_, err = agentTwo.Query(ctx, "anything to add?", nil)
+	require.NoError(t, err)
+
+	// Both agents' turns land on the one shared thread, in order.
+	got := conv.Messages()
+	require.Len(t, got, 4)
+	want := []string{
+		"what did you find?",
+		"agent one reporting",
+		"anything to add?",
+		"agent two building on that",
+	}
+	for i, w := range want {
+		msg, ok := got[i].(MessageTypeContent)
+		require.True(t, ok, "message %d has type %T", i, got[i])
+		assert.Equal(t, w, msg.Content, "message %d", i)
+	}
+}
+
 func TestSession_ConversationThreadSharing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -323,8 +406,7 @@ func TestSession_ConversationThreadSharing(t *testing.T) {
 	}
 
 	// A single shared conversation thread stands in for the request-context-owned
-	// thread every agent action in a plan reads from and appends to. In-memory
-	// (persist=false) so the test needs no storage backend.
+	// thread every agent action in a plan reads from and appends to.
 	conv := requestctx.NewConversation(conversationID)
 
 	t.Run("initial conversation with storage", func(t *testing.T) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -345,35 +345,36 @@ func TestSession_AgentsInSameRequestShareConversation(t *testing.T) {
 	secondLLM := NewMockLLmProvider(ctrl)
 	secondTools := NewMockToolManager(ctrl)
 	secondTools.EXPECT().ToolList(gomock.Any()).Return(nil).AnyTimes()
+	// The mock only records what it was handed; the checking happens on the test
+	// goroutine once Query has returned. Query only returns after the session
+	// closes its response channel, which happens-after this write, so the read is
+	// ordered without extra synchronisation.
+	var sentToProvider LLMRequest
 	secondLLM.EXPECT().ProvideResponse(gomock.Any(), gomock.Any()).
-		Do(func(_ context.Context, req LLMRequest) {
-			// assert, never require: this runs on the session's internal goroutine,
-			// where require's FailNow would kill the goroutine without closing the
-			// response channel — hanging the test instead of failing it.
-			if !assert.Len(t, req.Messages, 3) {
-				return
-			}
-			// agent 1's user turn + agent 1's answer + agent 2's own new query.
-			if seeded, ok := req.Messages[0].(MessageTypeContent); assert.True(t, ok,
-				"seeded message lost its concrete type: %T", req.Messages[0]) {
-				assert.Equal(t, RoleTypeUser, seeded.Role)
-				assert.Equal(t, "what did you find?", seeded.Content)
-			}
-			if answer, ok := req.Messages[1].(MessageTypeContent); assert.True(t, ok) {
-				assert.Equal(t, RoleTypeAssistant, answer.Role)
-				assert.Equal(t, "agent one reporting", answer.Content)
-			}
-		}).
+		Do(func(_ context.Context, req LLMRequest) { sentToProvider = req }).
 		Return(LLMResponse{Content: []ContentResponse{{Text: "agent two building on that"}}}, nil)
 
 	agentTwo, err := NewSession("second agent", secondLLM,
 		WithToolManager(secondTools),
 		WithConversation(rc.Conversation()))
 	require.NoError(t, err)
-	assert.Len(t, agentTwo.messages, 2, "agent two should be seeded with agent one's exchange")
+	require.Len(t, agentTwo.messages, 2, "agent two should be seeded with agent one's exchange")
 
 	_, err = agentTwo.Query(ctx, "anything to add?", nil)
 	require.NoError(t, err)
+
+	// Agent 1's turn and answer reached the provider ahead of agent 2's own query,
+	// with the concrete types intact through the []any boundary — if boxing lost
+	// them, the integrations' type switches would silently drop the history.
+	require.Len(t, sentToProvider.Messages, 3)
+	seeded, ok := sentToProvider.Messages[0].(MessageTypeContent)
+	require.True(t, ok, "seeded message lost its concrete type: %T", sentToProvider.Messages[0])
+	assert.Equal(t, RoleTypeUser, seeded.Role)
+	assert.Equal(t, "what did you find?", seeded.Content)
+	answer, ok := sentToProvider.Messages[1].(MessageTypeContent)
+	require.True(t, ok, "seeded message lost its concrete type: %T", sentToProvider.Messages[1])
+	assert.Equal(t, RoleTypeAssistant, answer.Role)
+	assert.Equal(t, "agent one reporting", answer.Content)
 
 	// Both agents' turns land on the one shared thread, in order.
 	got := conv.Messages()
@@ -620,101 +621,6 @@ func TestSession_ConversationThreadSharing(t *testing.T) {
 		assert.Nil(t, session.conversation)
 		assert.Empty(t, session.messages)
 	})
-}
-
-func TestSession_WithReturnOnlyLastMessage(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	systemPrompt := "You are a helpful assistant"
-	testQuery := "Tell me about the weather"
-
-	// First LLM response with tool call
-	firstResponse := LLMResponse{
-		Content: []ContentResponse{
-			{
-				Text: "I'll check the weather for you",
-			},
-		},
-		Tools: []ToolResponseObject{
-			{
-				Name: "get_weather",
-				Input: map[string]any{
-					"location": "default",
-				},
-				ToolID: "test",
-			},
-		},
-	}
-
-	// Final LLM response without tool call
-	finalResponse := LLMResponse{
-		Content: []ContentResponse{
-			{
-				Text: "The weather is sunny today",
-			},
-		},
-	}
-
-	mockToolManager := NewMockToolManager(ctrl)
-	mockLLmHandler := NewMockLLmProvider(ctrl)
-
-	// Setup expectations
-	var toolInfoList []ToolInfo
-	if err := json.Unmarshal([]byte(toolList), &toolInfoList); err != nil {
-		t.Fatal(err)
-	}
-	mockToolManager.EXPECT().ToolList(gomock.Any()).Return(toolInfoList)
-	mockToolManager.EXPECT().
-		CallTool(gomock.Any(), "get_weather", map[string]any{"location": "default"}).
-		Return([]mcp.Content{mcp.TextContent{Type: "text", Text: "Weather: Sunny, 25°C"}}, nil)
-
-	// We expect two LLM calls - one that returns a tool call, and one that gives the final response
-	gomock.InOrder(
-		mockLLmHandler.EXPECT().
-			ProvideResponse(gomock.Any(), gomock.Any()).
-			Return(firstResponse, nil),
-		mockLLmHandler.EXPECT().
-			ProvideResponse(gomock.Any(), gomock.Any()).
-			Return(finalResponse, nil),
-	)
-
-	// Test with returnOnlyLastMessage enabled
-
-	agent, err := NewSession(systemPrompt, mockLLmHandler, WithToolManager(mockToolManager), WithReturnOnlyLastMessage(), WithInstructions(testInstructions))
-	require.NoError(t, err)
-
-	response, err := agent.Query(context.Background(), testQuery, nil)
-	require.NoError(t, err)
-
-	// Should only contain the final response, not the first one
-	assert.Equal(t, "The weather is sunny today", response)
-	assert.NotContains(t, response, "I'll check the weather for you")
-
-	// Test without returnOnlyLastMessage (default behavior)
-	session2, err := NewSession(systemPrompt, mockLLmHandler, WithToolManager(mockToolManager), WithInstructions(testInstructions))
-	require.NoError(t, err)
-
-	mockToolManager.EXPECT().ToolList(gomock.Any()).Return(toolInfoList)
-	mockToolManager.EXPECT().
-		CallTool(gomock.Any(), "get_weather", map[string]any{"location": "default"}).
-		Return([]mcp.Content{mcp.TextContent{Type: "text", Text: "Weather: Sunny, 25°C"}}, nil)
-
-	gomock.InOrder(
-		mockLLmHandler.EXPECT().
-			ProvideResponse(gomock.Any(), gomock.Any()).
-			Return(firstResponse, nil),
-		mockLLmHandler.EXPECT().
-			ProvideResponse(gomock.Any(), gomock.Any()).
-			Return(finalResponse, nil),
-	)
-
-	response2, err := session2.Query(context.Background(), testQuery, nil)
-	require.NoError(t, err)
-
-	// Should contain both responses concatenated with newlines
-	assert.Contains(t, response2, "I'll check the weather for you")
-	assert.Contains(t, response2, "The weather is sunny today")
 }
 
 func TestCreateToolResponseFromMCPContent(t *testing.T) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -307,7 +308,7 @@ func TestOrchestrator_ToolErrorWithLLMWrapup(t *testing.T) {
 	assert.Contains(t, result, "I'm unable to complete the weather request due to an error")
 }
 
-func TestSession_ConversationIDMessageRetrieval(t *testing.T) {
+func TestSession_ConversationThreadSharing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -320,6 +321,11 @@ func TestSession_ConversationIDMessageRetrieval(t *testing.T) {
 	if err := json.Unmarshal([]byte(toolList), &toolInfoList); err != nil {
 		t.Fatal(err)
 	}
+
+	// A single shared conversation thread stands in for the request-context-owned
+	// thread every agent action in a plan reads from and appends to. In-memory
+	// (persist=false) so the test needs no storage backend.
+	conv := requestctx.NewConversation(conversationID)
 
 	t.Run("initial conversation with storage", func(t *testing.T) {
 		mockToolManager := NewMockToolManager(ctrl)
@@ -370,7 +376,7 @@ func TestSession_ConversationIDMessageRetrieval(t *testing.T) {
 		// Create session with conversation ID
 		session, err := NewSession(systemPrompt, mockLLmHandler,
 			WithToolManager(mockToolManager),
-			WithConversationID(context.Background(), conversationID),
+			WithConversation(conv),
 			WithInstructions(testInstructions))
 		require.NoError(t, err)
 
@@ -475,11 +481,11 @@ func TestSession_ConversationIDMessageRetrieval(t *testing.T) {
 
 			newSession, err := NewSession(systemPrompt, mockLLmHandler2,
 				WithToolManager(mockToolManager2),
-				WithConversationID(context.Background(), conversationID),
+				WithConversation(conv),
 				WithInstructions(testInstructions))
 			require.NoError(t, err)
 
-			// Verify that messages were loaded from storage + developer message
+			// Verify that messages were seeded from the shared thread
 			assert.Equal(t, 5, len(newSession.messages))
 
 			// Verify the loaded messages match what we expect
@@ -522,12 +528,15 @@ func TestSession_ConversationIDMessageRetrieval(t *testing.T) {
 		})
 	})
 
-	// Test error case: empty conversation ID
-	t.Run("error on empty conversation ID", func(t *testing.T) {
+	// A nil conversation is a safe no-op: the session keeps a purely local
+	// history rather than erroring (conversation creation is the request
+	// context's responsibility, not the session's).
+	t.Run("nil conversation is a no-op", func(t *testing.T) {
 		mockLLmHandler := NewMockLLmProvider(ctrl)
-		_, err := NewSession(systemPrompt, mockLLmHandler, WithConversationID(context.Background(), ""))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "conversationID can not be empty")
+		session, err := NewSession(systemPrompt, mockLLmHandler, WithConversation(nil))
+		require.NoError(t, err)
+		assert.Nil(t, session.conversation)
+		assert.Empty(t, session.messages)
 	})
 }
 

--- a/pkg/agent/structure.go
+++ b/pkg/agent/structure.go
@@ -2,44 +2,56 @@ package agent
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-type RoleType int
+// The conversation message types now live in requestctx (which owns the
+// run-scoped conversation thread). They are re-exported here as aliases so
+// existing callers — the LLM integrations' type switches, this package's
+// session loop, and tests — keep referring to them as agent.* unchanged.
+
+type RoleType = requestctx.RoleType
 
 const (
-	RoleTypeUnknown RoleType = iota
-	RoleTypeSystem
-	RoleTypeUser
-	RoleTypeAssistant
-	RoleTypeDeveloper
+	RoleTypeUnknown   = requestctx.RoleTypeUnknown
+	RoleTypeSystem    = requestctx.RoleTypeSystem
+	RoleTypeUser      = requestctx.RoleTypeUser
+	RoleTypeAssistant = requestctx.RoleTypeAssistant
+	RoleTypeDeveloper = requestctx.RoleTypeDeveloper
 )
 
-func (r RoleType) String() string {
-	switch r {
-	case RoleTypeSystem:
-		return "system"
-	case RoleTypeUser:
-		return "user"
-	case RoleTypeAssistant:
-		return "assistant"
-	case RoleTypeDeveloper:
-		return "developer"
-	default:
-		return "unknown"
-	}
-}
-
-type MessageType int
+type MessageType = requestctx.MessageType
 
 const (
-	MessageTypeText MessageType = iota
-	MessageTypeToolCall
-	MessageTypeToolResponse
+	MessageTypeText         = requestctx.MessageTypeText
+	MessageTypeToolCall     = requestctx.MessageTypeToolCall
+	MessageTypeToolResponse = requestctx.MessageTypeToolResponse
+)
+
+type (
+	Message                 = requestctx.Message
+	MessageTypeContent      = requestctx.MessageTypeContent
+	MessageToolCall         = requestctx.MessageToolCall
+	MessageToolCallResponse = requestctx.MessageToolCallResponse
+	ConversationMessage     = requestctx.ConversationMessage
+)
+
+type ToolResponseType = requestctx.ToolResponseType
+
+const (
+	ToolResponseTypeUnknown = requestctx.ToolResponseTypeUnknown
+	ToolResponseTypeText    = requestctx.ToolResponseTypeText
+	ToolResponseTypeImage   = requestctx.ToolResponseTypeImage
+)
+
+type ToolCallOutputType = requestctx.ToolCallOutputType
+
+const (
+	ToolCallOutputTypeText  = requestctx.ToolCallOutputTypeText
+	ToolCallOutputTypeImage = requestctx.ToolCallOutputTypeImage
 )
 
 type LLMRequest struct {
@@ -75,85 +87,6 @@ func TraceMessages(messages []any) string {
 		return ""
 	}
 	return string(b)
-}
-
-type MessageTypeContent struct {
-	Message
-	Role        RoleType
-	Content     string
-	FileContent *requestctx.FileValue `json:"-"`
-}
-
-func (c *MessageTypeContent) Serialize() ([]byte, error) {
-	return json.Marshal(c)
-}
-
-func (c *MessageTypeContent) Deserialize(bytes []byte) error {
-	return json.Unmarshal(bytes, c)
-}
-
-type Message struct {
-	Type MessageType `json:"type"`
-}
-
-type MessageToolCall struct {
-	Message
-	ID        string
-	Name      string
-	Arguments map[string]interface{}
-}
-
-func (t *MessageToolCall) Serialize() ([]byte, error) {
-	return json.Marshal(t)
-}
-
-func (t *MessageToolCall) Deserialize(bytes []byte) error {
-	return json.Unmarshal(bytes, t)
-}
-
-type ToolResponseType int
-
-const (
-	ToolResponseTypeUnknown ToolResponseType = iota
-	ToolResponseTypeText
-	ToolResponseTypeImage
-)
-
-type ToolCallOutputType int
-
-const (
-	ToolCallOutputTypeText ToolCallOutputType = iota
-	ToolCallOutputTypeImage
-)
-
-type MessageToolCallResponse struct {
-	Message
-	ToolResponseType ToolResponseType
-	ID               string
-	Text             string
-	ImageData        []byte
-	ImageMimeType    string
-}
-
-func (t *MessageToolCallResponse) GenerateContent() (content string, mimeType string, outputType ToolCallOutputType) {
-	switch t.ToolResponseType {
-	case ToolResponseTypeText:
-		return t.Text, "", ToolCallOutputTypeText
-	case ToolResponseTypeImage:
-		return fmt.Sprintf("data:%s;base64,%s", t.ImageMimeType, t.ImageData), t.ImageMimeType, ToolCallOutputTypeImage
-	default:
-		return t.Text, "", ToolCallOutputTypeText
-	}
-}
-
-// TODO consider removing image data when serializing for saving, so it won't be included in history
-
-func (t *MessageToolCallResponse) Serialize() ([]byte, error) {
-	return json.Marshal(t)
-}
-
-func (t *MessageToolCallResponse) Deserialize(bytes []byte) error {
-	return json.Unmarshal(bytes, t)
 }
 
 type ToolInfo struct {

--- a/pkg/engine/actions/executables/agent/exec.go
+++ b/pkg/engine/actions/executables/agent/exec.go
@@ -22,7 +22,6 @@ type Config struct {
 	SystemPrompt      string              `json:"systemPrompt" yaml:"systemPrompt"`
 	UserPrompt        string              `json:"userPrompt" yaml:"userPrompt"`
 	IntegrationID     string              `json:"integrationID" yaml:"integrationID"`
-	ConversationID    string              `json:"conversationID" yaml:"conversationID"`
 	ReturnLastMessage bool                `json:"returnLastMessage" yaml:"returnLastMessage"`
 	FileUpload        apiconfig.FileInput `json:"fileUpload" yaml:"fileUpload"`
 }
@@ -51,29 +50,46 @@ type Agent struct {
 	toolManager *tools.Manager
 }
 
-func (a *Agent) Config() string {
-	c, err := json.Marshal(a.config)
+// Execute is the V2 entrypoint: the action resolves its own templated fields
+// individually against the request context, so text produced by a template
+// (e.g. a JSON document interpolated into a prompt) can never corrupt the rest
+// of the config the way the V1 whole-string resolve-then-reparse did.
+//
+// Only the fields consumed NOW are resolved: the prompts and the file
+// identifier. ToolConfigs are deliberately left untouched — the tools manager
+// was built from the raw config at construction time and resolves tool-time
+// templates (returnValue, subgraph configs) when a tool is called.
+//
+// The conversation is no longer per-action: every agent action reads from and
+// appends to the request's shared conversation thread (owned by the request
+// context, selected once at plan start via the conversation id).
+func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, error) {
+	rc, err := requestctx.FromContextOrError(ctx)
 	if err != nil {
-		return ""
-	}
-	return string(c)
-}
-
-func (a *Agent) Execute(ctx context.Context, modifiedConfig string) (interface{}, map[string]string, error) {
-	var newConfig Config
-	if err := json.Unmarshal([]byte(modifiedConfig), &newConfig); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get request context: %w", err)
 	}
 
-	options := []agent.Option{agent.WithToolManager(a.toolManager)}
-	if newConfig.ConversationID != "" {
-		options = append(options, agent.WithConversationID(ctx, newConfig.ConversationID))
+	resolved, err := rc.ResolveBatch(ctx,
+		a.config.SystemPrompt,
+		a.config.UserPrompt,
+		a.config.FileUpload.Identifier,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve agent config: %w", err)
 	}
-	if newConfig.ReturnLastMessage {
+	systemPrompt, userPrompt := resolved[0], resolved[1]
+	fileUpload := a.config.FileUpload
+	fileUpload.Identifier = resolved[2]
+
+	options := []agent.Option{
+		agent.WithToolManager(a.toolManager),
+		agent.WithConversation(rc.Conversation()),
+	}
+	if a.config.ReturnLastMessage {
 		options = append(options, agent.WithReturnOnlyLastMessage())
 	}
 	session, err := agent.NewSession(
-		newConfig.SystemPrompt,
+		systemPrompt,
 		a.integration,
 		options...,
 	)
@@ -81,14 +97,14 @@ func (a *Agent) Execute(ctx context.Context, modifiedConfig string) (interface{}
 		return nil, nil, err
 	}
 
-	ctx, span := tracing.StartAgentInvoke(ctx, newConfig.IntegrationID)
+	ctx, span := tracing.StartAgentInvoke(ctx, a.config.IntegrationID)
 	defer span.End()
 
-	fileInput, err := requestctx.GetFileFromContext(ctx, newConfig.FileUpload)
+	fileInput, err := requestctx.GetFileFromContext(ctx, fileUpload)
 	if err != nil && !errors.Is(err, requestctx.ErrFileNotFound) {
 		return nil, nil, fmt.Errorf("%w: %v", actions.ErrorFatal, err)
 	}
-	resp, err := session.Query(ctx, newConfig.UserPrompt, fileInput)
+	resp, err := session.Query(ctx, userPrompt, fileInput)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -185,12 +201,6 @@ func init() {
 			Placeholder: "AI integration identifier",
 			Required:    true,
 		},
-		"conversationID": {
-			Type:        actions.FieldTypeString,
-			Label:       "Conversation ID",
-			Placeholder: "Conversation identifier",
-			Required:    false,
-		},
 		"returnLastMessage": {
 			Type:        actions.FieldTypeBoolean,
 			Label:       "Return Last Message",
@@ -204,7 +214,8 @@ func init() {
 		Name:        "AI Agent",
 		Description: "Interacts with AI models to process queries and execute tool functions",
 		Fields:      fields,
-		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
+		UseV2: true,
+		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {
 				return nil, fmt.Errorf("error creating agent action: %v", err)

--- a/pkg/engine/actions/executables/agent/exec.go
+++ b/pkg/engine/actions/executables/agent/exec.go
@@ -18,12 +18,11 @@ import (
 )
 
 type Config struct {
-	ToolConfigs       []ToolConfig        `json:"toolConfigs" yaml:"toolConfigs"`
-	SystemPrompt      string              `json:"systemPrompt" yaml:"systemPrompt"`
-	UserPrompt        string              `json:"userPrompt" yaml:"userPrompt"`
-	IntegrationID     string              `json:"integrationID" yaml:"integrationID"`
-	ReturnLastMessage bool                `json:"returnLastMessage" yaml:"returnLastMessage"`
-	FileUpload        apiconfig.FileInput `json:"fileUpload" yaml:"fileUpload"`
+	ToolConfigs   []ToolConfig        `json:"toolConfigs" yaml:"toolConfigs"`
+	SystemPrompt  string              `json:"systemPrompt" yaml:"systemPrompt"`
+	UserPrompt    string              `json:"userPrompt" yaml:"userPrompt"`
+	IntegrationID string              `json:"integrationID" yaml:"integrationID"`
+	FileUpload    apiconfig.FileInput `json:"fileUpload" yaml:"fileUpload"`
 }
 type MCPServerConfig struct {
 	Endpoint string   `json:"endpoint" yaml:"endpoint"`
@@ -63,6 +62,12 @@ type Agent struct {
 // The conversation is no longer per-action: every agent action reads from and
 // appends to the request's shared conversation thread (owned by the request
 // context, selected once at plan start via the conversation id).
+//
+// The action deliberately returns NO output. An agent's result is the messages
+// it contributed to the conversation — the session appends each one as it is
+// produced — so there is nothing to hand to later steps and no
+// {{ .variable_actions_<id> }} for them to read. Run output is extracted from
+// the thread instead.
 func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, error) {
 	rc, err := requestctx.FromContextOrError(ctx)
 	if err != nil {
@@ -85,9 +90,6 @@ func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, er
 		agent.WithToolManager(a.toolManager),
 		agent.WithConversation(rc.Conversation()),
 	}
-	if a.config.ReturnLastMessage {
-		options = append(options, agent.WithReturnOnlyLastMessage())
-	}
 	session, err := agent.NewSession(
 		systemPrompt,
 		a.integration,
@@ -104,8 +106,10 @@ func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, er
 	if err != nil && !errors.Is(err, requestctx.ErrFileNotFound) {
 		return nil, nil, fmt.Errorf("%w: %v", actions.ErrorFatal, err)
 	}
-	resp, err := session.Query(ctx, userPrompt, fileInput)
-	if err != nil {
+	// The reply is discarded on purpose: Query has already appended every message
+	// it produced to the shared conversation, which is where an agent's output
+	// lives now.
+	if _, err := session.Query(ctx, userPrompt, fileInput); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return nil, nil, err
@@ -122,7 +126,7 @@ func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, er
 		attribute.Int64(tracing.AttrUsageTotal, metadata.TotalUsage.InputTokens+metadata.TotalUsage.OutputTokens),
 	)
 
-	return resp, nil, nil
+	return nil, nil, nil
 }
 
 func (a *Agent) Type() string {
@@ -200,13 +204,6 @@ func init() {
 			Label:       "Integration ID",
 			Placeholder: "AI integration identifier",
 			Required:    true,
-		},
-		"returnLastMessage": {
-			Type:        actions.FieldTypeBoolean,
-			Label:       "Return Last Message",
-			Placeholder: "Whether to return only the last message",
-			Required:    false,
-			Default:     false,
 		},
 	}
 

--- a/pkg/engine/actions/executables/agent/exec.go
+++ b/pkg/engine/actions/executables/agent/exec.go
@@ -214,7 +214,7 @@ func init() {
 		Name:        "AI Agent",
 		Description: "Interacts with AI models to process queries and execute tool functions",
 		Fields:      fields,
-		UseV2: true,
+		UseV2:       true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/parallel/parallel_test.go
+++ b/pkg/engine/actions/executables/parallel/parallel_test.go
@@ -219,7 +219,13 @@ func TestParallelExec_Execute(t *testing.T) {
 		error2 := errors.New("action2 failed")
 		error3 := errors.New("action3 failed")
 
-		mockAction1.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, error1)
+		// Every step fails here, so the first error to arrive cancels the group and
+		// the remaining goroutines can return before they ever reach their action.
+		// Which one wins is down to scheduling, so no individual action may be
+		// required to run — asserting on a specific mock makes this flaky under
+		// different core counts and load. The contract under test is the shape of
+		// the returned error, checked below.
+		mockAction1.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, error1).AnyTimes()
 		mockAction2.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, error2).AnyTimes()
 		mockAction3.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil, error3).AnyTimes()
 

--- a/pkg/engine/plan/action_v2.go
+++ b/pkg/engine/plan/action_v2.go
@@ -111,7 +111,16 @@ func (a *ActionV2) execute(ctx context.Context) (*stepWrapper, error) {
 		}
 		reqCtx.AddActionFile(a.id, fileValue)
 		logger.Debug("stored action output as file", zap.String("action_output", a.id))
-	} else {
+	} else if resp != nil {
+		// A nil response means the action produces no output, so it publishes no
+		// request variable — an agent, for instance, contributes to the request
+		// conversation instead of handing a value to later steps. Templates cannot
+		// tell an absent key from a nil one (they are parsed with missingkey=zero),
+		// so this only removes the entry, it does not change how a template that
+		// still references the id renders.
+		//
+		// Only an untyped nil counts: an action returning a typed nil pointer is
+		// non-nil as an interface and still publishes.
 		if err = requestctx.AddRequestVariables(ctx, map[string]interface{}{a.id: resp}, ""); err != nil {
 			return nil, err
 		}

--- a/pkg/engine/plan/action_v2_test.go
+++ b/pkg/engine/plan/action_v2_test.go
@@ -1,0 +1,56 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestActionV2_OutputPublishing covers the request-variable contract: an action
+// that returns a value publishes it under its id, and an action that returns nil
+// publishes nothing at all. The nil case is what lets an action route its result
+// elsewhere — the agent action contributes to the request conversation instead of
+// handing a value to later steps.
+func TestActionV2_OutputPublishing(t *testing.T) {
+	t.Run("nil output writes no variable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := requestctx.NewTestContext()
+		exec := NewMockActionExecutableV2(ctrl)
+		exec.EXPECT().Type().Return("agent").AnyTimes()
+		exec.EXPECT().SupportsReplica().Return(false).AnyTimes()
+		exec.EXPECT().Execute(gomock.Any()).Return(nil, nil, nil)
+
+		action := &ActionV2{id: "silentaction", exec: exec}
+		_, err := action.execute(ctx)
+		require.NoError(t, err)
+
+		vars, err := requestctx.GetAllRequestVariables(ctx)
+		require.NoError(t, err)
+		_, present := vars["silentaction"]
+		assert.False(t, present, "a nil-returning action must not publish a request variable")
+	})
+
+	t.Run("non-nil output is published under the action id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := requestctx.NewTestContext()
+		exec := NewMockActionExecutableV2(ctrl)
+		exec.EXPECT().Type().Return("http").AnyTimes()
+		exec.EXPECT().SupportsReplica().Return(false).AnyTimes()
+		exec.EXPECT().Execute(gomock.Any()).Return("a result", nil, nil)
+
+		action := &ActionV2{id: "loudaction", exec: exec}
+		_, err := action.execute(ctx)
+		require.NoError(t, err)
+
+		vars, err := requestctx.GetAllRequestVariables(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "a result", vars["loudaction"])
+	})
+}

--- a/pkg/engine/plan/planner.go
+++ b/pkg/engine/plan/planner.go
@@ -14,6 +14,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// defaultDispatchTimeout caps a background dispatch chain when PlannerConfig
+// leaves DispatchTimeout unset. It has to accommodate an agent action, whose
+// runtime is the sum of every model round-trip plus tool calls across the loop —
+// a single LLM call is fast, but a multi-step agent easily runs for minutes.
+const defaultDispatchTimeout = 10 * time.Minute
+
 type ActionProvider interface {
 	GetActionExecutable(actionType string, config json.RawMessage) (actions.ActionExecutable, error)
 }
@@ -32,7 +38,7 @@ type PlannerConfig struct {
 	EndValue string
 
 	// DispatchTimeout is the timeout duration for background dispatch chains.
-	// If not set or set to 0, background actions will run without a timeout.
+	// If not set or set to 0, defaultDispatchTimeout applies.
 	DispatchTimeout time.Duration
 
 	// Workspace is the file capability that workspace-aware actions and template
@@ -96,7 +102,7 @@ func (p *PlannerV2) Plan() (*Plan, error) {
 
 	dispatchTimeout := p.config.DispatchTimeout
 	if dispatchTimeout == 0 {
-		dispatchTimeout = time.Minute
+		dispatchTimeout = defaultDispatchTimeout
 	}
 
 	// Build action name to ID mapping

--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -25,6 +25,7 @@ type RequestContext struct {
 	validationErrors []error
 	availableFiles   map[string]*FileValue
 	workspace        Workspace
+	conversation     *Conversation
 
 	// tokenInput/tokenOutput accumulate LLM token usage across every model call
 	// in this request. Observability-only — not exposed to workflow templates.

--- a/pkg/engine/requestctx/conversation.go
+++ b/pkg/engine/requestctx/conversation.go
@@ -1,0 +1,205 @@
+package requestctx
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Servflow/servflow/pkg/storage"
+)
+
+// conversationStoragePrefix namespaces persisted conversation messages in the
+// log store. Kept identical to the historic per-session prefix so threads
+// written before centralisation remain loadable.
+const conversationStoragePrefix = "agent_conversation_"
+
+// Conversation is the run-scoped message thread owned by a RequestContext.
+// Every agent action in a plan reads and appends to the SAME Conversation, so
+// the thread is the shared, mid-run-accessible record of everything the run's
+// agents have said and done. A Conversation always has an identifier and is
+// created once per request by Start (resumed from the log store when the id was
+// supplied, otherwise fresh); sub-workflows share it by pointer with the parent.
+//
+// Appends are in-memory only: the agent hot path never blocks on storage. The
+// thread is written to the log store once, at request completion (Flush).
+//
+// All methods are safe for concurrent use: the per-conversation mutex is what
+// stops parallel agent actions in the same request from clobbering each other —
+// a batch of messages is appended atomically, never interleaved mid-batch.
+type Conversation struct {
+	mu       sync.Mutex
+	id       string
+	messages []ConversationMessage
+	// flushed is the number of leading messages already written to the log store:
+	// messages[flushed:] is what a Flush still has to persist. Set by load to the
+	// size of the resumed history so that history is never written back.
+	flushed int
+}
+
+// NewConversation builds an empty conversation with the given identifier.
+// Appends go to memory; the thread is persisted when Flush is called (Start
+// arranges this at completion for the request that owns the thread). Production
+// code obtains its conversation from the RequestContext; this constructor is
+// exported for hosts that inject a thread and for tests.
+func NewConversation(id string) *Conversation {
+	return &Conversation{
+		id:       id,
+		messages: make([]ConversationMessage, 0),
+	}
+}
+
+// ID returns the conversation identifier.
+func (c *Conversation) ID() string {
+	return c.id
+}
+
+// Messages returns a snapshot copy of the thread so far. Callers (e.g. an agent
+// session seeding its working context) may retain and mutate the slice without
+// affecting the Conversation.
+func (c *Conversation) Messages() []ConversationMessage {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]ConversationMessage, len(c.messages))
+	copy(out, c.messages)
+	return out
+}
+
+// Append adds messages to the in-memory thread. It is the single method through
+// which agent actions contribute to the shared conversation, and it never
+// touches storage — persistence happens once at request completion. The whole
+// batch is appended under the lock, so concurrent agents cannot interleave
+// within it. A nil/empty call is a no-op.
+func (c *Conversation) Append(msgs ...ConversationMessage) {
+	if c == nil || len(msgs) == 0 {
+		return
+	}
+	c.mu.Lock()
+	c.messages = append(c.messages, msgs...)
+	c.mu.Unlock()
+}
+
+// flush writes the messages appended since the last flush to the log store and
+// advances the high-water mark, so a resumed thread only ever persists what the
+// current request added.
+func (c *Conversation) flush() error {
+	c.mu.Lock()
+	if c.id == "" || c.flushed >= len(c.messages) {
+		c.mu.Unlock()
+		return nil
+	}
+	pending := c.messages[c.flushed:]
+	batch := make([]storage.Serializable, len(pending))
+	for i := range pending {
+		batch[i] = pending[i]
+	}
+	high := len(c.messages)
+	id := c.id
+	c.mu.Unlock()
+
+	if err := storage.WriteToLog(conversationStoragePrefix+id, batch); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.flushed = high
+	c.mu.Unlock()
+	return nil
+}
+
+// Flush writes the messages added during this request to the log store. Called
+// once, at request completion, by the request that owns the conversation.
+func (c *Conversation) Flush() error {
+	if c == nil {
+		return nil
+	}
+	return c.flush()
+}
+
+// load prepends the stored thread for this conversation id, so a resumed run
+// starts with the existing history in front of anything it appends. It is called
+// by resolveConversation at construction — before any agent can append — so the
+// loaded messages are necessarily the leading ones. Unknown message types are
+// skipped (requestctx cannot depend on pkg/logging to warn — that would cycle).
+func (c *Conversation) load() error {
+	entries, err := storage.GetLogEntriesByPrefix(conversationStoragePrefix+c.id, decodeConversationMessage)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, e := range entries {
+		if msg, ok := e.(ConversationMessage); ok {
+			c.messages = append(c.messages, msg)
+		}
+	}
+	// Resumed messages are already in the store; the sync must only write
+	// messages appended after this point, never re-persist the loaded history.
+	c.flushed = len(c.messages)
+	return nil
+}
+
+// decodeConversationMessage deserialises a stored message back into its concrete
+// type. Returns (nil, nil) for unrecognised types so a single bad/legacy entry
+// does not abort the whole load.
+func decodeConversationMessage(data []byte) (any, error) {
+	var header Message
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, err
+	}
+	switch header.Type {
+	case MessageTypeText:
+		var m MessageTypeContent
+		return m, json.Unmarshal(data, &m)
+	case MessageTypeToolResponse:
+		var m MessageToolCallResponse
+		return m, json.Unmarshal(data, &m)
+	case MessageTypeToolCall:
+		var m MessageToolCall
+		return m, json.Unmarshal(data, &m)
+	default:
+		return nil, nil
+	}
+}
+
+// resolveConversation builds the Conversation for a request from its Options and
+// reports whether this request OWNS it (must run the background sync). A child
+// request with no explicit ConversationID joins its parent's thread by pointer
+// and does NOT own it. Otherwise a fresh thread is created — always with an
+// identifier (generated when none was supplied). A supplied id is resumed from
+// the store best-effort: a load failure yields an empty thread rather than
+// failing request start.
+func resolveConversation(opts Options) (conv *Conversation, owned bool) {
+	if opts.ConversationID == "" && opts.Parent != nil {
+		if pc := opts.Parent.Conversation(); pc != nil {
+			return pc, false
+		}
+	}
+	id := opts.ConversationID
+	if id == "" {
+		id = fmt.Sprintf("conversation_%d", time.Now().UnixNano())
+	}
+	conv = NewConversation(id)
+	if opts.ConversationID != "" {
+		_ = conv.load()
+	}
+	return conv, true
+}
+
+// Conversation returns the request's conversation thread. It is never nil for a
+// request opened via Start; the zero RequestContext (bare NewRequestContext /
+// tests) returns nil, which the Conversation methods tolerate.
+func (rc *RequestContext) Conversation() *Conversation {
+	rc.Lock()
+	defer rc.Unlock()
+	return rc.conversation
+}
+
+// setConversation installs the thread for this request. Used by Start.
+func (rc *RequestContext) setConversation(c *Conversation) {
+	rc.Lock()
+	defer rc.Unlock()
+	rc.conversation = c
+}

--- a/pkg/engine/requestctx/conversation.go
+++ b/pkg/engine/requestctx/conversation.go
@@ -165,9 +165,10 @@ func decodeConversationMessage(data []byte) (any, error) {
 }
 
 // resolveConversation builds the Conversation for a request from its Options and
-// reports whether this request OWNS it (must run the background sync). A child
+// reports whether this request OWNS it (must flush it at completion). A child
 // request with no explicit ConversationID joins its parent's thread by pointer
-// and does NOT own it. Otherwise a fresh thread is created — always with an
+// and does NOT own it — the parent, which completes last, persists the thread
+// for both. Otherwise a fresh thread is created — always with an
 // identifier (generated when none was supplied). A supplied id is resumed from
 // the store best-effort: a load failure yields an empty thread rather than
 // failing request start.

--- a/pkg/engine/requestctx/conversation_test.go
+++ b/pkg/engine/requestctx/conversation_test.go
@@ -1,0 +1,197 @@
+package requestctx
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// FromContextConversation fetches the conversation Start installed in ctx.
+func FromContextConversation(t *testing.T, ctx context.Context) *Conversation {
+	t.Helper()
+	rc, err := FromContextOrError(ctx)
+	if err != nil {
+		t.Fatalf("no request context: %v", err)
+	}
+	conv := rc.Conversation()
+	if conv == nil {
+		t.Fatal("request context has no conversation")
+	}
+	return conv
+}
+
+func textMsg(content string) MessageTypeContent {
+	return MessageTypeContent{
+		Message: Message{Type: MessageTypeText},
+		Role:    RoleTypeUser,
+		Content: content,
+	}
+}
+
+func contents(msgs []ConversationMessage) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		if c, ok := m.(MessageTypeContent); ok {
+			out = append(out, c.Content)
+		}
+	}
+	return out
+}
+
+// TestConversation_IncrementalFlushAndResume verifies that (a) flush only writes
+// the tail appended since the previous flush, and (b) resuming an id loads the
+// full thread exactly once — the load-time high-water mark prevents the resumed
+// history from being re-persisted on the next flush.
+func TestConversation_IncrementalFlushAndResume(t *testing.T) {
+	const id = "test-sync-incremental"
+
+	conv := NewConversation(id)
+	conv.Append(textMsg("one"), textMsg("two"))
+	if err := conv.flush(); err != nil {
+		t.Fatalf("first flush: %v", err)
+	}
+	if conv.flushed != 2 {
+		t.Fatalf("flushed = %d, want 2", conv.flushed)
+	}
+
+	// Second flush writes only the new tail; the first two are not re-written.
+	conv.Append(textMsg("three"))
+	if err := conv.flush(); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if conv.flushed != 3 {
+		t.Fatalf("flushed = %d, want 3", conv.flushed)
+	}
+
+	// A no-op flush (nothing pending) must not error or advance.
+	if err := conv.flush(); err != nil {
+		t.Fatalf("noop flush: %v", err)
+	}
+
+	// Resume: a fresh conversation loads the whole thread, once, in order.
+	resumed := NewConversation(id)
+	if err := resumed.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := contents(resumed.Messages())
+	want := []string{"one", "two", "three"}
+	if len(got) != len(want) {
+		t.Fatalf("resumed contents = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resumed[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+	// Loaded history is already persisted: flushed must equal the loaded count so
+	// the next flush is a no-op, not a duplicate write.
+	if resumed.flushed != len(want) {
+		t.Fatalf("resumed.flushed = %d, want %d", resumed.flushed, len(want))
+	}
+	if err := resumed.flush(); err != nil {
+		t.Fatalf("post-resume flush: %v", err)
+	}
+
+	// Loading again must still see exactly three (no duplication introduced).
+	check := NewConversation(id)
+	if err := check.load(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if n := len(check.Messages()); n != 3 {
+		t.Fatalf("reload count = %d, want 3", n)
+	}
+}
+
+// TestConversation_FlushAtRequestCompletion verifies the wiring Start relies on:
+// a conversation accumulates in memory and is persisted by the completion hook,
+// with nothing written before it fires.
+func TestConversation_FlushAtRequestCompletion(t *testing.T) {
+	const id = "test-flush-on-complete"
+
+	ctx, rc := Start(context.Background(), Options{ConversationID: id})
+	conv := FromContextConversation(t, ctx)
+	conv.Append(textMsg("during the request"))
+
+	// Nothing is persisted until the request completes.
+	before := NewConversation(id)
+	if err := before.load(); err != nil {
+		t.Fatalf("pre-completion load: %v", err)
+	}
+	if n := len(before.Messages()); n != 0 {
+		t.Fatalf("persisted %d messages before completion, want 0", n)
+	}
+
+	rc.Done() // main flow finished; no child flows → completes immediately
+
+	after := NewConversation(id)
+	if err := after.load(); err != nil {
+		t.Fatalf("post-completion load: %v", err)
+	}
+	if got := contents(after.Messages()); len(got) != 1 || got[0] != "during the request" {
+		t.Fatalf("persisted contents = %v, want [during the request]", got)
+	}
+}
+
+// TestConversation_ImageNotPersisted verifies image payloads never reach storage:
+// the bytes are dropped and the message is stored as a text tool result carrying
+// the metadata, while the in-memory message keeps its image intact.
+func TestConversation_ImageNotPersisted(t *testing.T) {
+	const id = "test-image-stripped"
+
+	imageBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	img := MessageToolCallResponse{
+		Message:          Message{Type: MessageTypeToolResponse},
+		ToolResponseType: ToolResponseTypeImage,
+		ID:               "tool_call_1",
+		ImageData:        imageBytes,
+		ImageMimeType:    "image/png",
+	}
+
+	conv := NewConversation(id)
+	conv.Append(img)
+	if err := conv.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// The live message is untouched — the model still gets the real image.
+	live, ok := conv.Messages()[0].(MessageToolCallResponse)
+	if !ok {
+		t.Fatalf("in-memory message type = %T", conv.Messages()[0])
+	}
+	if live.ToolResponseType != ToolResponseTypeImage || len(live.ImageData) != len(imageBytes) {
+		t.Fatalf("in-memory message was mutated: type=%v bytes=%d",
+			live.ToolResponseType, len(live.ImageData))
+	}
+
+	// The stored message carries metadata only.
+	resumed := NewConversation(id)
+	if err := resumed.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	msgs := resumed.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("resumed %d messages, want 1", len(msgs))
+	}
+	got, ok := msgs[0].(MessageToolCallResponse)
+	if !ok {
+		t.Fatalf("resumed message type = %T", msgs[0])
+	}
+	if len(got.ImageData) != 0 {
+		t.Fatalf("image bytes were persisted (%d bytes)", len(got.ImageData))
+	}
+	// Downgraded to text so a resumed thread is not rebuilt as an empty image
+	// block by the integrations.
+	if got.ToolResponseType != ToolResponseTypeText {
+		t.Fatalf("resumed ToolResponseType = %v, want text", got.ToolResponseType)
+	}
+	if got.ID != "tool_call_1" || got.ImageMimeType != "image/png" {
+		t.Fatalf("metadata lost: id=%q mime=%q", got.ID, got.ImageMimeType)
+	}
+	if !strings.Contains(got.Text, "image/png") || !strings.Contains(got.Text, "8 bytes") {
+		t.Fatalf("stored text %q lacks image metadata", got.Text)
+	}
+	content, _, outputType := got.GenerateContent()
+	if outputType != ToolCallOutputTypeText || content != got.Text {
+		t.Fatalf("resumed message renders as %v/%q, want text/%q", outputType, content, got.Text)
+	}
+}

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -56,8 +56,15 @@ type Options struct {
 	TemplateFuncsExclusive bool
 	// Parent links a sub-workflow to its caller: secrets are shared, and this
 	// request registers as a child flow of the parent, so the parent's total
-	// time transitively covers this request's entire lifetime.
+	// time transitively covers this request's entire lifetime. A child with no
+	// explicit ConversationID also joins the parent's conversation thread.
 	Parent *RequestContext
+	// ConversationID selects the run's conversation thread. When set, the thread
+	// is resumed from the log store (empty if new) so a later request with the
+	// same id continues it. When empty, a fresh thread with a generated id is
+	// created. Either way the thread is synced to the log store in the background;
+	// agents read and append in memory.
+	ConversationID string
 }
 
 // Start opens a request and its main flow. The caller MUST call Done() when
@@ -78,6 +85,22 @@ func Start(ctx context.Context, opts Options) (context.Context, *RequestContext)
 		opts.Parent.ShareSecretsWith(rc)
 		end := opts.Parent.BeginFlow("workflow:" + id)
 		rc.RegisterOnCompleteHook(end)
+	}
+	conv, owned := resolveConversation(opts)
+	rc.setConversation(conv)
+	if owned {
+		// The conversation lives in memory for the request and is written once, at
+		// completion — which is after the response is sent AND after child flows
+		// drain, so a sub-workflow's messages are included and the client waits on
+		// nothing. Only the owning request flushes; adopted threads are persisted
+		// by the request that created them.
+		flushLogger := opts.Logger
+		rc.RegisterOnCompleteHook(func() {
+			if err := conv.Flush(); err != nil && flushLogger != nil {
+				flushLogger.Warn("failed to persist conversation",
+					zap.String("conversation_id", conv.ID()), zap.Error(err))
+			}
+		})
 	}
 	ctx = WithAggregationContext(ctx, rc)
 	if opts.Logger != nil {

--- a/pkg/engine/requestctx/messages.go
+++ b/pkg/engine/requestctx/messages.go
@@ -1,0 +1,188 @@
+package requestctx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Servflow/servflow/pkg/storage"
+)
+
+// ConversationMessage is a single entry in a conversation thread. Every message
+// type can serialize itself for persistence and render a short human-readable
+// summary — the summary is what lets a thread be inspected or previewed at any
+// point of a run without re-interpreting each concrete message type.
+//
+// The concrete types (MessageTypeContent, MessageToolCall,
+// MessageToolCallResponse) implement this interface on VALUE receivers so a
+// stored value satisfies ConversationMessage and still matches the LLM
+// integrations' type switches over []any (case MessageTypeContent: ...).
+type ConversationMessage interface {
+	storage.Serializable // Serialize() ([]byte, error)
+	// Summary returns a short, single-line human-readable description of the
+	// message for thread previews and logging. It never returns file bytes or
+	// image data.
+	Summary() string
+}
+
+// summaryLimit bounds the length of the free-text portion of a message summary.
+const summaryLimit = 120
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+type RoleType int
+
+const (
+	RoleTypeUnknown RoleType = iota
+	RoleTypeSystem
+	RoleTypeUser
+	RoleTypeAssistant
+	RoleTypeDeveloper
+)
+
+func (r RoleType) String() string {
+	switch r {
+	case RoleTypeSystem:
+		return "system"
+	case RoleTypeUser:
+		return "user"
+	case RoleTypeAssistant:
+		return "assistant"
+	case RoleTypeDeveloper:
+		return "developer"
+	default:
+		return "unknown"
+	}
+}
+
+type MessageType int
+
+const (
+	MessageTypeText MessageType = iota
+	MessageTypeToolCall
+	MessageTypeToolResponse
+)
+
+// Message is the common header embedded in every concrete message type.
+type Message struct {
+	Type MessageType `json:"type"`
+}
+
+type MessageTypeContent struct {
+	Message
+	Role        RoleType
+	Content     string
+	FileContent *FileValue `json:"-"`
+}
+
+func (c MessageTypeContent) Serialize() ([]byte, error) {
+	return json.Marshal(c)
+}
+
+func (c *MessageTypeContent) Deserialize(bytes []byte) error {
+	return json.Unmarshal(bytes, c)
+}
+
+func (c MessageTypeContent) Summary() string {
+	s := fmt.Sprintf("%s: %s", c.Role, truncate(c.Content, summaryLimit))
+	if c.FileContent != nil {
+		s += " [file]"
+	}
+	return s
+}
+
+type MessageToolCall struct {
+	Message
+	ID        string
+	Name      string
+	Arguments map[string]interface{}
+}
+
+func (t MessageToolCall) Serialize() ([]byte, error) {
+	return json.Marshal(t)
+}
+
+func (t *MessageToolCall) Deserialize(bytes []byte) error {
+	return json.Unmarshal(bytes, t)
+}
+
+func (t MessageToolCall) Summary() string {
+	args, err := json.Marshal(t.Arguments)
+	if err != nil {
+		args = []byte("{}")
+	}
+	return fmt.Sprintf("tool call %s(%s)", t.Name, truncate(string(args), summaryLimit))
+}
+
+type ToolResponseType int
+
+const (
+	ToolResponseTypeUnknown ToolResponseType = iota
+	ToolResponseTypeText
+	ToolResponseTypeImage
+)
+
+type ToolCallOutputType int
+
+const (
+	ToolCallOutputTypeText ToolCallOutputType = iota
+	ToolCallOutputTypeImage
+)
+
+type MessageToolCallResponse struct {
+	Message
+	ToolResponseType ToolResponseType
+	ID               string
+	Text             string
+	ImageData        []byte
+	ImageMimeType    string
+}
+
+func (t MessageToolCallResponse) GenerateContent() (content string, mimeType string, outputType ToolCallOutputType) {
+	switch t.ToolResponseType {
+	case ToolResponseTypeText:
+		return t.Text, "", ToolCallOutputTypeText
+	case ToolResponseTypeImage:
+		return fmt.Sprintf("data:%s;base64,%s", t.ImageMimeType, t.ImageData), t.ImageMimeType, ToolCallOutputTypeImage
+	default:
+		return t.Text, "", ToolCallOutputTypeText
+	}
+}
+
+// Serialize renders the message for persistence. Image payloads are NOT stored:
+// the bytes are dropped and the message is persisted as a text tool result
+// carrying only the metadata (mime type and original size).
+//
+// The response type is downgraded to text deliberately. A stored message that
+// kept ToolResponseTypeImage with no bytes would, once a later request resumed
+// the thread, be rebuilt by the integrations as an image block with empty
+// base64 data and rejected by the provider — breaking every subsequent turn.
+// As text the resumed thread stays coherent and honest about what was dropped.
+//
+// The value receiver means this mutates only the copy being serialized: the
+// live in-memory message keeps its bytes, so the model still receives the real
+// image during the request that produced it.
+func (t MessageToolCallResponse) Serialize() ([]byte, error) {
+	if t.ToolResponseType == ToolResponseTypeImage {
+		size := len(t.ImageData)
+		t.ImageData = nil
+		t.ToolResponseType = ToolResponseTypeText
+		t.Text = fmt.Sprintf("[image omitted: %s, %d bytes]", t.ImageMimeType, size)
+	}
+	return json.Marshal(t)
+}
+
+func (t *MessageToolCallResponse) Deserialize(bytes []byte) error {
+	return json.Unmarshal(bytes, t)
+}
+
+func (t MessageToolCallResponse) Summary() string {
+	if t.ToolResponseType == ToolResponseTypeImage {
+		return fmt.Sprintf("tool result %s: [image %s]", t.ID, t.ImageMimeType)
+	}
+	return fmt.Sprintf("tool result %s: %s", t.ID, truncate(t.Text, summaryLimit))
+}

--- a/pkg/engine/server/handler.go
+++ b/pkg/engine/server/handler.go
@@ -182,6 +182,10 @@ func (h *APIHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		Logger: h.baseLogger.With(
 			zap.String("method", req.Method), zap.String("path", req.URL.Path)),
 		SpanAttributes: h.spanAttrs,
+		// An optional client-supplied id resumes a persisted conversation thread
+		// that every agent action in the plan shares; absent, a fresh in-memory
+		// thread is created for this request.
+		ConversationID: req.Header.Get("X-Conversation-Id"),
 	})
 	req = req.WithContext(ctx)
 	// The lifecycle (bound in StartHTTPEntry) owns the root span: Done stamps


### PR DESCRIPTION
Agent message history lived inside each agent action's own Session, so agents in the same run could not see each other's messages and handing off meant squeezing everything through string templates. Persistence was opt-in per action and wrote to badger synchronously on the agent loop.

Move the conversation into the request context, which now owns a single run-scoped thread every agent action reads from and appends to:

- Message types move to requestctx behind a ConversationMessage interface (Serialize + Summary). pkg/agent re-exports them as aliases, so the LLM integrations' type switches are untouched. Value receivers keep the concrete types matching when boxed through the []any LLM boundary.
- Conversation is guarded by a per-instance mutex: a batch is appended atomically, so parallel agents in one request cannot clobber each other.
- Appends are in-memory only. The thread is written to the log store once, at request completion, after the response is sent and child flows have drained. A resumed thread is prepended from storage and its high-water mark set, so loaded history is never written back.
- Start takes a ConversationID (sourced from X-Conversation-Id) to resume a thread; a sub-workflow with no id of its own adopts its parent's.
- Image payloads are no longer persisted: the bytes are dropped and the message is stored as a text tool result carrying mime type and size. The type downgrade matters because a stored image message with no bytes would be rebuilt as an empty base64 image block and rejected by the provider.

The per-action conversationID config field is removed; the thread is now selected once per request rather than per agent.