### PR TITLE
integration configs: typed {value}/{secret} fields, drop lazy loading

### DIFF
--- a/examples/db-agent/integrations.yaml
+++ b/examples/db-agent/integrations.yaml
@@ -1,23 +1,32 @@
 # Integration Configuration for Database Agent Example
 # This file shows how to configure MongoDB and OpenAI integrations
 # required for the AI-powered database agent endpoint.
+#
+# Each config field is an object: {value: <literal>} for a plain value, or
+# {secret: <key>} to reference a stored secret by key.
 
 integrations:
   # MongoDB Integration
   my_database:
     type: mongo
     config:
-      connectionString: '{{ secret "MONGODB_STRING" }}'
-      dbName: myapp
+      connectionString:
+        secret: MONGODB_STRING
+      dbName:
+        value: myapp
 
   # OpenAI Integration for AI capabilities
   my_openai_service:
     type: openai
     config:
-      api_key: '{{ secret "OPENAI_API_KEY" }}'
-      model: gpt-3.5-turbo
-      temperature: 0.7
-      max_tokens: 1500
+      api_key:
+        secret: OPENAI_API_KEY
+      model:
+        value: gpt-3.5-turbo
+      temperature:
+        value: 0.7
+      max_tokens:
+        value: 1500
 # Example secrets that need to be configured:
 # MONGODB_STRING: mongodb://username:password@localhost:27017
 # OPENAI_API_KEY: sk-your-openai-api-key-here
@@ -33,12 +42,16 @@ integrations:
 # my_database:
 #   type: sql
 #   config:
-#     connectionString: '{{ secret "POSTGRES_CONNECTION_STRING" }}'
-#     driver: postgres
+#     connectionString:
+#       secret: POSTGRES_CONNECTION_STRING
+#     driver:
+#       value: postgres
 #
 # MySQL Integration:
 # my_database:
 #   type: sql
 #   config:
-#     connectionString: '{{ secret "MYSQL_CONNECTION_STRING" }}'
-#     driver: mysql
+#     connectionString:
+#       secret: MYSQL_CONNECTION_STRING
+#     driver:
+#       value: mysql

--- a/examples/user-registration/configs/user-registration.yaml
+++ b/examples/user-registration/configs/user-registration.yaml
@@ -7,8 +7,10 @@ integrations:
   my_database:
     type: mongo
     config:
-      connectionString: '{{ secret "MONGODB_STRING" }}'
-      dbName: myapp
+      connectionString:
+        secret: MONGODB_STRING
+      dbName:
+        value: myapp
 
 # API Endpoint Configuration
 id: user_registration

--- a/examples/user-registration/integrations.yaml
+++ b/examples/user-registration/integrations.yaml
@@ -1,23 +1,32 @@
 # Integration Configuration for User Registration Example
 # This file shows how to configure database and JWT integrations
 # required for the user registration API endpoint.
+#
+# Each config field is an object: {value: <literal>} for a plain value, or
+# {secret: <key>} to reference a stored secret by key.
 
 integrations:
   # MongoDB Integration
   my_database:
     type: mongo
     config:
-      connectionString: '{{ secret "MONGODB_STRING" }}'
-      dbName: myapp
+      connectionString:
+        secret: MONGODB_STRING
+      dbName:
+        value: myapp
 
   # JWT Integration (if using separate JWT service)
   # Note: JWT can also be handled directly in actions without a separate integration
   jwt_service:
     type: jwt
     config:
-      secret: '{{ secret "JWT_SECRET" }}'
-      algorithm: HS256
-      expiration: 24h
+      # The field is named "secret"; its value references the JWT_SECRET secret.
+      secret:
+        secret: JWT_SECRET
+      algorithm:
+        value: HS256
+      expiration:
+        value: 24h
 # Example secrets that need to be configured:
 # MONGODB_STRING: mongodb://username:password@localhost:27017
 # JWT_SECRET: your-super-secure-jwt-secret-key-here

--- a/pkg/apiconfig/apiconfig.go
+++ b/pkg/apiconfig/apiconfig.go
@@ -137,30 +137,17 @@ func (o *ResponseObject) ToProto() *proto.ResponseObject {
 }
 
 type IntegrationConfig struct {
-	ID       string                 `json:"id" yaml:"id"`
-	Config   map[string]interface{} `json:"config,omitempty" yaml:"config,omitempty"`
-	Type     string                 `json:"type" yaml:"type"`
-	LazyLoad bool                   `json:"lazyLoad" yaml:"lazyLoad"`
+	ID     string                 `json:"id" yaml:"id"`
+	Config map[string]ConfigValue `json:"config,omitempty" yaml:"config,omitempty"`
+	Type   string                 `json:"type" yaml:"type"`
 }
 
-//	func (d *IntegrationConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-//		var tmp struct {
-//			Type      string                 `yaml:"type"`
-//			NewConfig map[string]interface{} `yaml:"config"`
-//			ID        string                 `yaml:"id"`
-//		}
-//		if err := unmarshal(&tmp); err != nil {
-//			return err
-//		}
-//
-//		data, err := json.Marshal(tmp.NewConfig)
-//		if err != nil {
-//			return err
-//		}
-//
-//		d.Type = tmp.Type
-//		d.Config = data
-//		d.ID = tmp.ID
-//		d.NewConfig = tmp.NewConfig
-//		return nil
-//	}
+// ConfigValue is one integration config field. It is either a literal (Value)
+// or a reference to a stored secret (Secret). Secret wins when both are set;
+// an unset Secret means the field is used as written. The engine resolves these
+// to a plain map[string]any before handing the config to an integration
+// constructor — see pkg/engine/integration.
+type ConfigValue struct {
+	Value  any    `json:"value,omitempty" yaml:"value,omitempty"`
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+}

--- a/pkg/apiconfig/configvalue_test.go
+++ b/pkg/apiconfig/configvalue_test.go
@@ -1,0 +1,62 @@
+package apiconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigValueRoundTrip(t *testing.T) {
+	cases := map[string]struct {
+		value    ConfigValue
+		wantJSON string
+		wantYAML string
+	}{
+		"literal string": {
+			value:    ConfigValue{Value: "Iv1.abc"},
+			wantJSON: `{"value":"Iv1.abc"}`,
+			wantYAML: "value: Iv1.abc\n",
+		},
+		"secret ref": {
+			value:    ConfigValue{Secret: "github_app_pem"},
+			wantJSON: `{"secret":"github_app_pem"}`,
+			wantYAML: "secret: github_app_pem\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotJSON, err := json.Marshal(tc.value)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wantJSON, string(gotJSON))
+
+			var backJSON ConfigValue
+			require.NoError(t, json.Unmarshal(gotJSON, &backJSON))
+			assert.Equal(t, tc.value, backJSON)
+
+			gotYAML, err := yaml.Marshal(tc.value)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantYAML, string(gotYAML))
+
+			var backYAML ConfigValue
+			require.NoError(t, yaml.Unmarshal(gotYAML, &backYAML))
+			assert.Equal(t, tc.value, backYAML)
+		})
+	}
+}
+
+// A config map decodes from both codecs into the wrapped shape.
+func TestIntegrationConfigDecode(t *testing.T) {
+	const raw = `{"id":"gh","type":"github_app","config":{"client_id":{"value":"Iv1.abc"},"pem":{"secret":"gh_pem"}}}`
+
+	var cfg IntegrationConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &cfg))
+
+	assert.Equal(t, "Iv1.abc", cfg.Config["client_id"].Value)
+	assert.Equal(t, "", cfg.Config["client_id"].Secret)
+	assert.Equal(t, "gh_pem", cfg.Config["pem"].Secret)
+	assert.Nil(t, cfg.Config["pem"].Value)
+}

--- a/pkg/engine/actions/executables/authenticate/authenticate_test.go
+++ b/pkg/engine/actions/executables/authenticate/authenticate_test.go
@@ -51,7 +51,7 @@ func TestAuthenticate_New(t *testing.T) {
 			return mockInvalidIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("invalid", "invalidds", nil, false)
+		err := integration.InitializeIntegration("invalid", "invalidds", nil)
 		require.NoError(t, err)
 
 		_, err = New(Config{
@@ -72,7 +72,7 @@ func TestAuthenticate_New(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{
@@ -123,7 +123,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{
@@ -159,7 +159,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{
@@ -193,7 +193,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{
@@ -238,7 +238,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err = integration.InitializeIntegration("mock", "mockds", nil, false)
+		err = integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{
@@ -282,7 +282,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		auth, err := New(Config{

--- a/pkg/engine/actions/executables/delete_action/delete_test.go
+++ b/pkg/engine/actions/executables/delete_action/delete_test.go
@@ -21,7 +21,7 @@ func TestNewDeleteAction(t *testing.T) {
 	integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 		return mockIntegration, nil
 	})
-	err := integration.InitializeIntegration("mock", "testID", nil, false)
+	err := integration.InitializeIntegration("mock", "testID", nil)
 	require.NoError(t, err)
 
 	del, err := New(Config{
@@ -63,7 +63,7 @@ func TestDelete_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		d, err := New(Config{
@@ -101,7 +101,7 @@ func TestDelete_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		d, err := New(Config{
 			IntegrationID:     "mockds",
@@ -132,7 +132,7 @@ func TestDelete_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		d, err := New(Config{
 			IntegrationID:     "mockds",

--- a/pkg/engine/actions/executables/fetch/fetch_test.go
+++ b/pkg/engine/actions/executables/fetch/fetch_test.go
@@ -28,7 +28,7 @@ func TestFetch_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		fetch, err := New(Config{
@@ -58,7 +58,7 @@ func TestFetch_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		fetch, err := New(Config{
 			Table:         "mock",
@@ -86,7 +86,7 @@ func TestFetch_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		fetch, err := New(Config{
 			Table:         "mock",

--- a/pkg/engine/actions/executables/fetchvector/fetchvector_test.go
+++ b/pkg/engine/actions/executables/fetchvector/fetchvector_test.go
@@ -33,7 +33,7 @@ func TestFetchVector_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err = integration.InitializeIntegration("mock", "mockid", nil, false)
+		err = integration.InitializeIntegration("mock", "mockid", nil)
 		require.NoError(t, err)
 
 		fetchVectorObj := FetchVector{
@@ -69,7 +69,7 @@ func TestFetchVector_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err = integration.InitializeIntegration("mock", "mockid", nil, false)
+		err = integration.InitializeIntegration("mock", "mockid", nil)
 		require.NoError(t, err)
 
 		fetchVectorObj := FetchVector{

--- a/pkg/engine/actions/executables/save/save_test.go
+++ b/pkg/engine/actions/executables/save/save_test.go
@@ -32,7 +32,7 @@ func TestSave_Insert(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		save, err := New(Config{
@@ -60,7 +60,7 @@ func TestSave_Insert(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		save, err := New(Config{
@@ -91,7 +91,7 @@ func TestSave_Insert(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		save, err := New(Config{
 			IntegrationID: "mockds",
@@ -129,7 +129,7 @@ func TestSave_Update(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		save, err := New(Config{
@@ -161,7 +161,7 @@ func TestSave_Update(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		save, err := New(Config{
 			IntegrationID: "mockds",
@@ -205,7 +205,7 @@ func TestSave_Type(t *testing.T) {
 	integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 		return mockIntegration, nil
 	})
-	integration.InitializeIntegration("mock", "mockds", nil, false)
+	integration.InitializeIntegration("mock", "mockds", nil)
 
 	save, err := New(Config{
 		IntegrationID: "mockds",

--- a/pkg/engine/actions/executables/storevector/storevector_test.go
+++ b/pkg/engine/actions/executables/storevector/storevector_test.go
@@ -30,7 +30,7 @@ func TestStoreVectors_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err = integration.InitializeIntegration("mock", "mockid", nil, false)
+		err = integration.InitializeIntegration("mock", "mockid", nil)
 		require.NoError(t, err)
 
 		storeVectors, err := New(Config{
@@ -60,7 +60,7 @@ func TestStoreVectors_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]interface{}) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockid", nil, false)
+		integration.InitializeIntegration("mock", "mockid", nil)
 
 		storeVectors, err := New(Config{
 			IntegrationID: "mockid",

--- a/pkg/engine/actions/executables/update/update_test.go
+++ b/pkg/engine/actions/executables/update/update_test.go
@@ -32,7 +32,7 @@ func TestUpdate_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		update, err := New(Config{
@@ -67,7 +67,7 @@ func TestUpdate_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		update, err := New(Config{
 			IntegrationID:     "mockds",

--- a/pkg/engine/actions/executables/write/write_test.go
+++ b/pkg/engine/actions/executables/write/write_test.go
@@ -24,7 +24,7 @@ func TestStore_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		store, err := New(Config{
@@ -55,7 +55,7 @@ func TestStore_Execute(t *testing.T) {
 			return mockIntegration, nil
 		})
 
-		err := integration.InitializeIntegration("mock", "mockds", nil, false)
+		err := integration.InitializeIntegration("mock", "mockds", nil)
 		require.NoError(t, err)
 
 		store, err := New(Config{
@@ -82,7 +82,7 @@ func TestStore_Execute(t *testing.T) {
 		integration.ReplaceIntegrationType("mock", func(m map[string]any) (integration.Integration, error) {
 			return mockIntegration, nil
 		})
-		integration.InitializeIntegration("mock", "mockds", nil, false)
+		integration.InitializeIntegration("mock", "mockds", nil)
 
 		store, err := New(Config{
 			IntegrationID:     "mockds",

--- a/pkg/engine/integration/integrations.go
+++ b/pkg/engine/integration/integrations.go
@@ -2,18 +2,13 @@
 package integration
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	apiconfig "github.com/Servflow/servflow/pkg/apiconfig"
-	"github.com/Servflow/servflow/pkg/engine/requestctx"
 	"github.com/Servflow/servflow/pkg/engine/secrets"
 	"github.com/Servflow/servflow/pkg/logging"
 	"go.uber.org/zap"
@@ -59,18 +54,11 @@ type RegistrationInfo struct {
 type Manager struct {
 	integrations          sync.Map
 	availableConstructors map[string]RegistrationInfo
-	lazyIntegrations      sync.Map
-}
-
-type LazyIntegration struct {
-	Type   string
-	Config json.RawMessage
 }
 
 var integrationManager = &Manager{
 	availableConstructors: make(map[string]RegistrationInfo),
 	integrations:          sync.Map{},
-	lazyIntegrations:      sync.Map{},
 }
 
 type Integration interface {
@@ -142,56 +130,42 @@ func GetInfoForIntegration(integrationType string) (RegistrationInfo, error) {
 	return info, nil
 }
 
-func GetLazyLoadedIntegrations() map[string]LazyIntegration {
-	integrations := make(map[string]LazyIntegration)
-	integrationManager.lazyIntegrations.Range(func(key, value interface{}) bool {
-		integration := value.(LazyIntegration)
-		integrations[key.(string)] = integration
-		return true
-	})
-	return integrations
+// InitializeFromConfig resolves an integration config (fetching any secrets)
+// and constructs the integration, replacing any prior instance under the same
+// id.
+func InitializeFromConfig(cfg apiconfig.IntegrationConfig) error {
+	conf, err := resolveConfig(cfg.ID, cfg.Config)
+	if err != nil {
+		return fmt.Errorf("could not resolve integration config: %w", err)
+	}
+	return InitializeIntegration(cfg.Type, cfg.ID, conf)
 }
 
-func InitializeIntegration(integrationType, id string, config map[string]any, shouldLazyLoad bool) error {
+// InitializeIntegration constructs the integration for integrationType under id
+// and stores it, replacing any prior instance. The config is already resolved
+// (secrets fetched) by the time it reaches here.
+func InitializeIntegration(integrationType, id string, config map[string]any) error {
 	info, ok := integrationManager.availableConstructors[integrationType]
 	if !ok {
 		return fmt.Errorf("integration type %s not registered", integrationType)
 	}
 
-	if shouldLazyLoad {
-		jsonConfig, err := json.Marshal(config)
-		if err != nil {
-			return err
-		}
-
-		// Purge any prior instance/config for this id (shutting down a live one)
-		// before storing, so a reload doesn't leak the old integration or leave a
-		// stale eager entry that would shadow this lazy config.
-		integrationManager.removeIntegration(id)
-		integrationManager.lazyIntegrations.Store(id, LazyIntegration{
-			Type:   integrationType,
-			Config: jsonConfig,
-		})
-	} else {
-		integration, err := info.Constructor(config)
-		if err != nil {
-			return err
-		}
-
-		// Construct first; only once the new instance is ready do we shut down and
-		// remove the old one, so a failed reload leaves the working integration intact.
-		integrationManager.removeIntegration(id)
-		integrationManager.integrations.Store(id, integration)
+	integration, err := info.Constructor(config)
+	if err != nil {
+		return err
 	}
+
+	// Construct first; only once the new instance is ready do we shut down and
+	// remove the old one, so a failed reload leaves the working integration intact.
+	integrationManager.removeIntegration(id)
+	integrationManager.integrations.Store(id, integration)
 
 	return nil
 }
 
-// removeIntegration drops any existing instance and lazy config registered under
-// id. A live instance implementing Shutdownable is shut down (bounded by a short
-// timeout) before removal so reloads don't leak resources. Removing from both
-// maps also clears stale cross-map entries when an integration switches between
-// eager and lazy loading.
+// removeIntegration drops any existing instance registered under id. A live
+// instance implementing Shutdownable is shut down (bounded by a short timeout)
+// before removal so reloads don't leak resources.
 func (m *Manager) removeIntegration(id string) {
 	if existing, ok := m.integrations.Load(id); ok {
 		if shutdownable, ok := existing.(Shutdownable); ok {
@@ -204,57 +178,15 @@ func (m *Manager) removeIntegration(id string) {
 		}
 		m.integrations.Delete(id)
 	}
-	m.lazyIntegrations.Delete(id)
 }
 
-// TODO the config is being converted to and from json multiple times, fix that
-
-// GetIntegration gets an initialized registration from the list of integration
-// as an interface
+// GetIntegration returns the initialized integration registered under id.
 func GetIntegration(ctx context.Context, id string) (Integration, error) {
-	//var (
-	//	integration any
-	//	ok          bool
-	//)
 	integration, ok := integrationManager.integrations.Load(id)
 	if !ok {
-		lazyIntegrationConf, ok := integrationManager.lazyIntegrations.Load(id)
-		if !ok {
-			return nil, fmt.Errorf("integration %s not registered", id)
-		}
-
-		lazyIntegration := lazyIntegrationConf.(LazyIntegration)
-		info, err := GetInfoForIntegration(lazyIntegration.Type)
-		if err != nil {
-			return nil, fmt.Errorf("could not find info to lazy load integration for %s: %w", id, err)
-		}
-
-		tmpl, err := requestctx.CreateTextTemplate(ctx, string(lazyIntegration.Config), nil)
-		if err != nil {
-			if errors.Is(err, requestctx.ErrNoContext) {
-				return nil, fmt.Errorf("lazy loaded integration being called early or without a context: %w", err)
-			}
-			return nil, err
-		}
-
-		cfg, err := requestctx.ExecuteTemplateFromContext(ctx, tmpl)
-		if err != nil {
-			return nil, err
-		}
-
-		config := map[string]any{}
-		if err := json.Unmarshal([]byte(cfg), &config); err != nil {
-			return nil, err
-		}
-		integration, err := info.Constructor(config)
-		if err != nil {
-			return nil, fmt.Errorf("could not lazy load integration for %s: %w", id, err)
-		}
-
-		return integration, nil
-	} else {
-		return integration.(Integration), nil
+		return nil, fmt.Errorf("integration %s not registered", id)
 	}
+	return integration.(Integration), nil
 }
 
 func RegisterIntegrationsFromConfig(ctx context.Context, integrationsConfig []apiconfig.IntegrationConfig) error {
@@ -275,51 +207,11 @@ func RegisterIntegrationsFromConfig(ctx context.Context, integrationsConfig []ap
 	for _, dsConfig := range integrationsConfig {
 		go func(config *apiconfig.IntegrationConfig) {
 			defer wg.Done()
-			var (
-				conf map[string]any
-				buf  bytes.Buffer
-			)
 
-			confStr, err := json.Marshal(config.Config)
-			if err != nil {
+			if err := InitializeFromConfig(*config); err != nil {
 				errChan <- &errorReport{
 					integrationID: config.ID,
-					error:         fmt.Errorf("could not marshal integration config: %w", err),
-				}
-			}
-
-			confParsed := parseString(string(confStr))
-			tmpl, err := template.New("config").Funcs(template.FuncMap{
-				"secret": func(key string) string {
-					return secrets.FetchSecret(key)
-				},
-			}).Parse(confParsed)
-
-			if err != nil {
-				errChan <- &errorReport{
-					integrationID: config.ID,
-					error:         err,
-				}
-				return
-			}
-
-			if err := tmpl.Execute(&buf, map[string]string{}); err != nil {
-				errChan <- &errorReport{
-					integrationID: config.ID,
-					error:         err,
-				}
-			}
-			if err := json.Unmarshal(buf.Bytes(), &conf); err != nil {
-				errChan <- &errorReport{
-					integrationID: config.ID,
-					error:         err,
-				}
-			}
-
-			if err := InitializeIntegration(dsConfig.Type, dsConfig.ID, conf, dsConfig.LazyLoad); err != nil {
-				errChan <- &errorReport{
-					integrationID: config.ID,
-					error:         fmt.Errorf("error initializing integration with ID %s and type %s: %w", dsConfig.ID, dsConfig.Type, err),
+					error:         fmt.Errorf("error initializing integration with ID %s and type %s: %w", config.ID, config.Type, err),
 				}
 				return
 			}
@@ -345,6 +237,25 @@ func RegisterIntegrationsFromConfig(ctx context.Context, integrationsConfig []ap
 	}
 }
 
-func parseString(s string) string {
-	return strings.ReplaceAll(s, `\"`, `"`)
+// resolveConfig materializes an integration's stored config for its
+// constructor. A field that names a secret is fetched from the secret manager;
+// anything else passes through as written. Secret wins when both are set.
+//
+// A named-but-missing secret is a hard error rather than a silent empty value:
+// an integration credential is never usefully empty, so surfacing it here as a
+// boot/reload failure that names the field beats a confusing auth error later.
+func resolveConfig(id string, config map[string]apiconfig.ConfigValue) (map[string]any, error) {
+	resolved := make(map[string]any, len(config))
+	for field, v := range config {
+		if v.Secret == "" {
+			resolved[field] = v.Value
+			continue
+		}
+		val := secrets.FetchSecret(v.Secret)
+		if val == "" {
+			return nil, fmt.Errorf("integration %q: field %q: secret %q not found", id, field, v.Secret)
+		}
+		resolved[field] = val
+	}
+	return resolved, nil
 }

--- a/pkg/engine/integration/integrations_test.go
+++ b/pkg/engine/integration/integrations_test.go
@@ -1,10 +1,11 @@
 package integration
 
 import (
-	"encoding/json"
+	"context"
+	"sync"
 	"testing"
 
-	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	apiconfig "github.com/Servflow/servflow/pkg/apiconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,60 +33,158 @@ func TestIntegrationManager(t *testing.T) {
 	require.Error(t, err, "expected error registering mock integration")
 
 	t.Run("InitializeIntegration", func(t *testing.T) {
-		err := InitializeIntegration("mock", "mock-1", map[string]any{"key": "value"}, false)
+		err := InitializeIntegration("mock", "mock-1", map[string]any{"key": "value"})
 		require.NoError(t, err)
 
 		_, ok := integrationManager.integrations.Load("mock-1")
 		require.True(t, ok, "Integration was not stored in the manager")
 
-		err = InitializeIntegration("unknown", "unknown-1", nil, false)
+		err = InitializeIntegration("unknown", "unknown-1", nil)
 		require.Error(t, err, "Expected error when initializing unregistered integration")
 	})
 
-	t.Run("InitializeIntegration lazy load", func(t *testing.T) {
-		err := InitializeIntegration("mock", "mock-2", map[string]any{"key": "value"}, true)
+	t.Run("GetIntegration returns the constructed instance", func(t *testing.T) {
+		require.NoError(t, InitializeIntegration("mock", "mock-2", map[string]any{"key": "value"}))
+
+		got, err := GetIntegration(context.Background(), "mock-2")
 		require.NoError(t, err)
+		mock, ok := got.(*mockIntegration)
+		require.True(t, ok)
+		assert.Equal(t, "MockIntegration", mock.Name())
+	})
 
-		_, ok := integrationManager.integrations.Load("mock-2")
-		assert.False(t, ok, "Integration should not be preloaded to manager")
-
-		v, ok := integrationManager.lazyIntegrations.Load("mock-2")
-		assert.True(t, ok, "Integration be lazy loaded to manager")
-
-		conf, ok := v.(LazyIntegration)
-		assert.True(t, ok, "Integration should be lazy loaded to manager")
-
-		confBytes, err := json.Marshal(conf.Config)
-		require.NoError(t, err)
-		assert.Equal(t, conf.Type, "mock")
-		assert.Equal(t, json.RawMessage(confBytes), conf.Config)
+	t.Run("GetIntegration on an unknown id errors", func(t *testing.T) {
+		_, err := GetIntegration(context.Background(), "nope")
+		require.Error(t, err)
 	})
 }
 
-func TestIntegrationManager_LazyLoad(t *testing.T) {
+const testPEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIEabc123
+-----END RSA PRIVATE KEY-----`
+
+// registerCapturingMock registers a "mock" integration type whose constructor
+// records the config it was handed, so a test can assert on what the resolver
+// produced.
+func registerCapturingMock(t *testing.T) func() map[string]any {
+	t.Helper()
+
 	integrationManager = &Manager{
 		availableConstructors: make(map[string]RegistrationInfo),
 	}
-	mockConstructor := func(config map[string]any) (Integration, error) {
-		return &mockIntegration{name: "MockIntegration"}, nil
-	}
 
+	var (
+		mu     sync.Mutex
+		gotCfg map[string]any
+	)
 	err := RegisterIntegration("mock", RegistrationInfo{
-		Name:        "Mock",
-		Description: "Mock integration for testing",
-		Constructor: mockConstructor,
+		Name: "Mock",
+		Constructor: func(config map[string]any) (Integration, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			gotCfg = config
+			return &mockIntegration{name: "MockIntegration"}, nil
+		},
 	})
 	require.NoError(t, err, "registering mock integration")
 
-	err = InitializeIntegration("mock", "mock-1", map[string]any{"key": "value"}, true)
-	require.NoError(t, err)
+	return func() map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotCfg
+	}
+}
 
-	integration, err := GetIntegration(requestctx.NewTestContext(), "mock-1")
-	assert.NoError(t, err)
+func literal(v any) apiconfig.ConfigValue { return apiconfig.ConfigValue{Value: v} }
+func secretRef(k string) apiconfig.ConfigValue {
+	return apiconfig.ConfigValue{Secret: k}
+}
 
-	mockIntegration, ok := integration.(*mockIntegration)
-	assert.True(t, ok)
-	assert.Equal(t, "MockIntegration", mockIntegration.Name())
+func TestRegisterIntegrationsFromConfig(t *testing.T) {
+	t.Run("literals pass through with their types", func(t *testing.T) {
+		captured := registerCapturingMock(t)
+
+		err := RegisterIntegrationsFromConfig(context.Background(), []apiconfig.IntegrationConfig{{
+			ID:   "typed",
+			Type: "mock",
+			Config: map[string]apiconfig.ConfigValue{
+				"host": literal("db.example.com"),
+				"port": literal(float64(5432)),
+				"tls":  literal(true),
+			},
+		}})
+		require.NoError(t, err)
+
+		cfg := captured()
+		require.NotNil(t, cfg, "constructor should have been called")
+		assert.Equal(t, "db.example.com", cfg["host"])
+		assert.Equal(t, float64(5432), cfg["port"])
+		assert.Equal(t, true, cfg["tls"])
+	})
+
+	t.Run("a multi-line secret reaches the constructor intact", func(t *testing.T) {
+		captured := registerCapturingMock(t)
+		t.Setenv("github_app_pem", testPEM)
+
+		err := RegisterIntegrationsFromConfig(context.Background(), []apiconfig.IntegrationConfig{{
+			ID:   "gh",
+			Type: "mock",
+			Config: map[string]apiconfig.ConfigValue{
+				"client_id": literal("Iv1.abc"),
+				"pem":       secretRef("github_app_pem"),
+			},
+		}})
+		require.NoError(t, err)
+
+		cfg := captured()
+		require.NotNil(t, cfg)
+		assert.Equal(t, testPEM, cfg["pem"])
+		assert.Equal(t, "Iv1.abc", cfg["client_id"])
+	})
+
+	t.Run("a missing secret errors and does not initialize", func(t *testing.T) {
+		captured := registerCapturingMock(t)
+
+		err := RegisterIntegrationsFromConfig(context.Background(), []apiconfig.IntegrationConfig{{
+			ID:     "missing",
+			Type:   "mock",
+			Config: map[string]apiconfig.ConfigValue{"token": secretRef("nope_not_set")},
+		}})
+		require.Error(t, err)
+
+		assert.Nil(t, captured(), "constructor must not run when a secret is missing")
+		_, ok := integrationManager.integrations.Load("missing")
+		assert.False(t, ok, "a failed integration must not be registered")
+	})
+}
+
+func TestResolveConfig(t *testing.T) {
+	t.Run("secret wins when both are set", func(t *testing.T) {
+		t.Setenv("s", "from-secret")
+		got, err := resolveConfig("id", map[string]apiconfig.ConfigValue{
+			"field": {Value: "from-literal", Secret: "s"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "from-secret", got["field"])
+	})
+
+	t.Run("literal is used when no secret is named", func(t *testing.T) {
+		got, err := resolveConfig("id", map[string]apiconfig.ConfigValue{
+			"field": {Value: "plain"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "plain", got["field"])
+	})
+
+	t.Run("a missing secret names the integration, field and key", func(t *testing.T) {
+		_, err := resolveConfig("gh", map[string]apiconfig.ConfigValue{
+			"pem": secretRef("absent_key"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `integration "gh"`)
+		assert.Contains(t, err.Error(), `field "pem"`)
+		assert.Contains(t, err.Error(), `secret "absent_key"`)
+	})
 }
 
 // Mock integration for testing

--- a/pkg/engine/plan/apiconfig_schema.json
+++ b/pkg/engine/plan/apiconfig_schema.json
@@ -289,13 +289,19 @@
           "type": "string"
         },
         "config": {
-          "type": ["object", "null"]
+          "type": ["object", "null"],
+          "description": "Map of field name to a value object: {\"value\": <literal>} or {\"secret\": \"<key>\"}.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value": {},
+              "secret": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
         },
         "type": {
           "type": "string"
-        },
-        "lazyLoad": {
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/pkg/engine/plan/planner.go
+++ b/pkg/engine/plan/planner.go
@@ -74,7 +74,8 @@ func NewPlannerV2(config PlannerConfig, logger *zap.Logger) *PlannerV2 {
 func (p *PlannerV2) Plan() (*Plan, error) {
 	for id := range p.config.Integrations {
 		integ := p.config.Integrations[id]
-		if err := integration.InitializeIntegration(integ.Type, id, integ.Config, integ.LazyLoad); err != nil {
+		integ.ID = id
+		if err := integration.InitializeFromConfig(integ); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/engine/plan/planner_test.go
+++ b/pkg/engine/plan/planner_test.go
@@ -452,7 +452,7 @@ func TestPlannerV2_IntegrationsLazyLoaded(t *testing.T) {
 			integrationID: {
 				ID:     integrationID,
 				Type:   "mock-planner-test",
-				Config: map[string]interface{}{"key": "value"},
+				Config: map[string]apiconfig.ConfigValue{"key": {Value: "value"}},
 			},
 		}
 
@@ -478,12 +478,12 @@ func TestPlannerV2_IntegrationsLazyLoaded(t *testing.T) {
 			"multi-integration-1": {
 				ID:     "multi-integration-1",
 				Type:   "mock-planner-test",
-				Config: map[string]interface{}{"setting": "one"},
+				Config: map[string]apiconfig.ConfigValue{"setting": {Value: "one"}},
 			},
 			"multi-integration-2": {
 				ID:     "multi-integration-2",
 				Type:   "mock-planner-test",
-				Config: map[string]interface{}{"setting": "two"},
+				Config: map[string]apiconfig.ConfigValue{"setting": {Value: "two"}},
 			},
 		}
 
@@ -511,7 +511,7 @@ func TestPlannerV2_IntegrationsLazyLoaded(t *testing.T) {
 			"unknown-integration": {
 				ID:     "unknown-integration",
 				Type:   "unknown-type-xyz",
-				Config: map[string]interface{}{"key": "value"},
+				Config: map[string]apiconfig.ConfigValue{"key": {Value: "value"}},
 			},
 		}
 

--- a/pkg/engine/server/config_loader_test.go
+++ b/pkg/engine/server/config_loader_test.go
@@ -129,13 +129,17 @@ integrations:
   db1:
     type: mongo
     config:
-      connectionString: "mongodb://localhost:27017"
-      database: "testdb"
+      connectionString:
+        value: "mongodb://localhost:27017"
+      database:
+        value: "testdb"
   db2:
     type: sql
     config:
-      driver: "postgres"
-      connectionString: "postgres://user:pass@localhost/db"
+      driver:
+        value: "postgres"
+      connectionString:
+        secret: db2_connection_string
 `
 		err := os.WriteFile(tempFile, []byte(engineYAML), 0644)
 		require.NoError(t, err)

--- a/testsuite/compose/config.yml
+++ b/testsuite/compose/config.yml
@@ -2,5 +2,7 @@ integrations:
   mongo:
     type: mongo
     config:
-      connectionString: '{{ secret "MONGODB_STRING" }}'
-      dbName: servflow
+      connectionString:
+        secret: MONGODB_STRING
+      dbName:
+        value: servflow


### PR DESCRIPTION
An integration config field used to be a flat value that could smuggle a `{{ secret "…" }}` template. The whole config was rendered as text and re-parsed to expand those, which mangled any secret carrying a newline, quote or backslash — a GitHub App PEM, most obviously.

Each field is now one of two objects: {value: <literal>} or {secret: <key>}. Resolution fetches the secret and hands it to the constructor as a plain Go string — no escaping, no re-parse. A named but missing secret now fails at boot/reload naming the integration, field and key, instead of silently resolving to "".

Lazy integrations go with it: they existed only to defer the template pass to request time, which no longer exists. Every integration now constructs when it registers, so broken config surfaces immediately. InitializeIntegration loses its lazy arg; InitializeFromConfig is the shared resolve-then-construct entry for the loader and the planner.

apiconfig.IntegrationConfig.Config becomes map[string]ConfigValue and LazyLoad is removed. Fixtures, examples and the config schema move to the wrapped shape.