### PR TITLE
Drop back-compat shims from refs, templates and conversation load

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
       - until redis-cli -h cache ping; do sleep 1; done
 
   - name: code-quality
-    image: golang
+    image: golang:1.25
     volumes:
       - name: deps
         path: /go
@@ -45,7 +45,7 @@ steps:
       - staticcheck ./...
 
   - name: test
-    image: golang
+    image: golang:1.25
     privileged: true
     depends_on:
       - wait-for-redis

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ServFlow Engine is part of the ServFlow platform. Use it standalone (free foreve
 http:
   listenPath: /users
   method: GET
-  next: $action.fetch_users
+  next: action.fetch_users
 
 actions:
   fetch_users:
@@ -48,7 +48,7 @@ actions:
     config:
       collection: users
       integrationID: mongo
-    next: $response.success
+    next: response.success
 
 responses:
   success:
@@ -160,7 +160,7 @@ name: Users API
 http:
   listenPath: /users
   method: GET
-  next: $action.fetch_users
+  next: action.fetch_users
 # ... rest of configuration
 ```
 

--- a/examples/db-agent/configs/db-agent.yaml
+++ b/examples/db-agent/configs/db-agent.yaml
@@ -45,8 +45,8 @@ actions:
     type: mongoquery
     config:
       collection: users
-      filter: '{{ tool_param "filter" | stringescape }}'
-      projection: '{{ tool_param "projection" | stringescape }}'
+      filter: '{{ tool_param "filter" | escape }}'
+      projection: '{{ tool_param "projection" | escape }}'
       integrationID: "my_database"
 
 responses:

--- a/pkg/apiconfig/reference.go
+++ b/pkg/apiconfig/reference.go
@@ -7,8 +7,7 @@ import (
 
 // Step-reference prefixes. A workflow step refers to the next step to run by a
 // prefixed string id, e.g. "action.createUser", "conditional.isValid",
-// "response.ok". These constants are the canonical home for those prefixes;
-// requestctx aliases them for backwards compatibility.
+// "response.ok". These constants are the canonical home for those prefixes.
 const (
 	ActionConfigPrefix      = "action."
 	ConditionalConfigPrefix = "conditional."
@@ -40,34 +39,26 @@ func (k StepKind) String() string {
 
 // ParseStepRef parses a step reference into its kind and bare id.
 //
-// A leading "$" is stripped (backwards compatibility). An empty reference is
-// terminal: the chain ends and there is no further step (terminal=true, no
-// error). An unrecognized prefix is an error.
+// An empty reference is terminal: the chain ends and there is no further step
+// (terminal=true, no error). An unrecognized prefix is an error.
 //
 // This is the single source of truth for reference resolution; both the planner
 // and the config validator use it so they can never disagree on what a
 // reference means.
 func ParseStepRef(raw string) (kind StepKind, id string, terminal bool, err error) {
-	s := strings.TrimPrefix(raw, "$")
-	if s == "" {
+	if raw == "" {
 		return StepKindUnknown, "", true, nil
 	}
 	switch {
-	case strings.HasPrefix(s, ActionConfigPrefix):
-		return StepKindAction, strings.TrimPrefix(s, ActionConfigPrefix), false, nil
-	case strings.HasPrefix(s, ConditionalConfigPrefix):
-		return StepKindConditional, strings.TrimPrefix(s, ConditionalConfigPrefix), false, nil
-	case strings.HasPrefix(s, ResponsesConfigPrefix):
-		return StepKindResponse, strings.TrimPrefix(s, ResponsesConfigPrefix), false, nil
+	case strings.HasPrefix(raw, ActionConfigPrefix):
+		return StepKindAction, strings.TrimPrefix(raw, ActionConfigPrefix), false, nil
+	case strings.HasPrefix(raw, ConditionalConfigPrefix):
+		return StepKindConditional, strings.TrimPrefix(raw, ConditionalConfigPrefix), false, nil
+	case strings.HasPrefix(raw, ResponsesConfigPrefix):
+		return StepKindResponse, strings.TrimPrefix(raw, ResponsesConfigPrefix), false, nil
 	default:
-		return StepKindUnknown, s, false, fmt.Errorf(
+		return StepKindUnknown, raw, false, fmt.Errorf(
 			"invalid step reference %q: must start with %q, %q, or %q",
 			raw, ActionConfigPrefix, ConditionalConfigPrefix, ResponsesConfigPrefix)
 	}
-}
-
-// CanonicalStepID returns the reference with any leading "$" stripped, i.e. the
-// form used as the key in a plan's step map. Empty (terminal) refs return "".
-func CanonicalStepID(raw string) string {
-	return strings.TrimPrefix(raw, "$")
 }

--- a/pkg/apiconfig/reference_test.go
+++ b/pkg/apiconfig/reference_test.go
@@ -12,11 +12,9 @@ func TestParseStepRef(t *testing.T) {
 		wantErr  bool
 	}{
 		{"empty is terminal", "", StepKindUnknown, "", true, false},
-		{"dollar empty is terminal", "$", StepKindUnknown, "", true, false},
 		{"action ref", "action.createUser", StepKindAction, "createUser", false, false},
 		{"conditional ref", "conditional.isValid", StepKindConditional, "isValid", false, false},
 		{"response ref", "response.ok", StepKindResponse, "ok", false, false},
-		{"dollar prefix stripped", "$action.foo", StepKindAction, "foo", false, false},
 		{"bare word is error", "end", StepKindUnknown, "end", false, true},
 		{"unknown prefix is error", "step.foo", StepKindUnknown, "step.foo", false, true},
 	}

--- a/pkg/engine/actions/registry.go
+++ b/pkg/engine/actions/registry.go
@@ -72,7 +72,9 @@ func (r *Registry) RegisterAction(actionType string, registration ActionRegistra
 	return nil
 }
 
-// GetFieldsForAction kept for backward compatibility
+// GetFieldsForAction returns the field metadata registered for an action type:
+// what the dashboard renders as a form, and what config validation checks a
+// step's config against. It errors when the type is not registered.
 func GetFieldsForAction(actionType string) (map[string]FieldInfo, error) {
 	f, ok := actionManager.availableConstructors[actionType]
 	if !ok {

--- a/pkg/engine/plan/planner.go
+++ b/pkg/engine/plan/planner.go
@@ -26,13 +26,6 @@ type ActionProvider interface {
 
 // PlannerConfig holds config values for the plan generation
 type PlannerConfig struct {
-	// ResultTag is the key that holds the value copied from EndLookupKey
-	ResultTag string
-	// EndLookupKey is the key that should be looked up to get the value copied to
-	// the ResultTag, without the "."
-	// Deprecated: use EndValue instead
-	EndLookupKey string
-
 	// EndValue is the value to be used as the ending of this plan, it can be
 	// raw string or go template
 	EndValue string
@@ -147,9 +140,7 @@ func (p *PlannerV2) generateStep(id string) (*stepWrapper, error) {
 		return nil, nil
 	}
 
-	// canonical id (with any leading "$" stripped) is the step map key
-	canonical := apiconfig.CanonicalStepID(id)
-	if st, ok := p.finalSteps[canonical]; ok {
+	if st, ok := p.finalSteps[id]; ok {
 		return &st, nil
 	}
 
@@ -167,10 +158,10 @@ func (p *PlannerV2) generateStep(id string) (*stepWrapper, error) {
 	}
 
 	stepWr := stepWrapper{
-		id:   canonical,
+		id:   id,
 		step: step,
 	}
-	p.finalSteps[canonical] = stepWr
+	p.finalSteps[id] = stepWr
 	return &stepWr, nil
 }
 

--- a/pkg/engine/plan/validation_graph.go
+++ b/pkg/engine/plan/validation_graph.go
@@ -72,12 +72,11 @@ func collectGraphErrors(a *apiconfig.APIConfig, ve *ValidationErrors, extraRoots
 			ve.Add(&InvalidReferenceError{From: from, To: ref, Reason: err.Error()})
 			return "", false
 		}
-		canonical := apiconfig.CanonicalStepID(ref)
-		if _, ok := nodes[canonical]; !ok {
+		if _, ok := nodes[ref]; !ok {
 			ve.Add(&InvalidReferenceError{From: from, To: ref, Reason: fmt.Sprintf("no %s named %q", kind, bare)})
 			return "", false
 		}
-		return canonical, true
+		return ref, true
 	}
 
 	// flow edges (next/fail/onTrue/onFalse) used for cycle detection + reachability

--- a/pkg/engine/requestctx/conversation.go
+++ b/pkg/engine/requestctx/conversation.go
@@ -10,8 +10,7 @@ import (
 )
 
 // conversationStoragePrefix namespaces persisted conversation messages in the
-// log store. Kept identical to the historic per-session prefix so threads
-// written before centralisation remain loadable.
+// log store; the conversation id follows it to key one thread.
 const conversationStoragePrefix = "agent_conversation_"
 
 // Conversation is the run-scoped message thread owned by a RequestContext.
@@ -121,8 +120,7 @@ func (c *Conversation) Flush() error {
 // load prepends the stored thread for this conversation id, so a resumed run
 // starts with the existing history in front of anything it appends. It is called
 // by resolveConversation at construction — before any agent can append — so the
-// loaded messages are necessarily the leading ones. Unknown message types are
-// skipped (requestctx cannot depend on pkg/logging to warn — that would cycle).
+// loaded messages are necessarily the leading ones.
 func (c *Conversation) load() error {
 	entries, err := storage.GetLogEntriesByPrefix(conversationStoragePrefix+c.id, decodeConversationMessage)
 	if err != nil {
@@ -131,9 +129,11 @@ func (c *Conversation) load() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, e := range entries {
-		if msg, ok := e.(ConversationMessage); ok {
-			c.messages = append(c.messages, msg)
+		msg, ok := e.(ConversationMessage)
+		if !ok {
+			return fmt.Errorf("conversation %s: stored entry is a %T, not a message", c.id, e)
 		}
+		c.messages = append(c.messages, msg)
 	}
 	// Resumed messages are already in the store; the sync must only write
 	// messages appended after this point, never re-persist the loaded history.
@@ -142,8 +142,10 @@ func (c *Conversation) load() error {
 }
 
 // decodeConversationMessage deserialises a stored message back into its concrete
-// type. Returns (nil, nil) for unrecognised types so a single bad/legacy entry
-// does not abort the whole load.
+// type. A type it does not recognise is a corrupt entry and fails the read:
+// resuming a thread with a message missing from the middle of it would hand the
+// model a conversation that never happened. resolveConversation treats a failed
+// load as an empty thread, so the request still starts.
 func decodeConversationMessage(data []byte) (any, error) {
 	var header Message
 	if err := json.Unmarshal(data, &header); err != nil {
@@ -160,7 +162,7 @@ func decodeConversationMessage(data []byte) (any, error) {
 		var m MessageToolCall
 		return m, json.Unmarshal(data, &m)
 	default:
-		return nil, nil
+		return nil, fmt.Errorf("unknown conversation message type %q", header.Type)
 	}
 }
 

--- a/pkg/engine/requestctx/templates.go
+++ b/pkg/engine/requestctx/templates.go
@@ -90,22 +90,21 @@ func (rc *RequestContext) executeTemplate(tmpl *template.Template) (string, erro
 func (rc *RequestContext) getFuncMap(funcMap template.FuncMap) template.FuncMap {
 	m := template.FuncMap{
 		// Base functions
-		"strip":        tmplStripText,
-		"jsonout":      jsonOut,
-		"pluck":        tmplPluck,
-		"escape":       stringEscape,
-		"stringescape": stringEscape, // backward compatibility
-		"jsonraw":      jsonRaw,
-		"join":         tmplJoin,
-		"hash":         tmplHash,
-		"now":          now,
-		"secret":       rc.tmplFuncSecret,
-		"tostring":     tostring,
-		"email":        rc.tmplFuncEmail,
-		"empty":        rc.tmplFuncEmpty,
-		"notempty":     rc.tmplFuncNotEmpty,
-		"bcrypt":       rc.tmplFuncBcrypt,
-		"file":         rc.tmplFuncFile,
+		"strip":    tmplStripText,
+		"jsonout":  jsonOut,
+		"pluck":    tmplPluck,
+		"escape":   stringEscape,
+		"jsonraw":  jsonRaw,
+		"join":     tmplJoin,
+		"hash":     tmplHash,
+		"now":      now,
+		"secret":   rc.tmplFuncSecret,
+		"tostring": tostring,
+		"email":    rc.tmplFuncEmail,
+		"empty":    rc.tmplFuncEmpty,
+		"notempty": rc.tmplFuncNotEmpty,
+		"bcrypt":   rc.tmplFuncBcrypt,
+		"file":     rc.tmplFuncFile,
 	}
 	// Add request-scoped functions (param, header, body, urlparam, etc.)
 	for k, v := range rc.requestFuncs {

--- a/pkg/engine/requestctx/templates_test.go
+++ b/pkg/engine/requestctx/templates_test.go
@@ -113,7 +113,7 @@ func TestTemplateFunctions(t *testing.T) {
 		},
 		{
 			name:          "string escape direct usage",
-			templateInput: `Escaped: {{stringescape .input}}`,
+			templateInput: `Escaped: {{escape .input}}`,
 			values: map[string]interface{}{
 				"input": "hello \"world\"\nwith\tspecial chars\\",
 			},
@@ -122,7 +122,7 @@ func TestTemplateFunctions(t *testing.T) {
 		},
 		{
 			name:          "string escape with empty string",
-			templateInput: `Escaped: {{stringescape .input}}`,
+			templateInput: `Escaped: {{escape .input}}`,
 			values: map[string]interface{}{
 				"input": "",
 			},

--- a/testsuite/compose/confs/login.yml
+++ b/testsuite/compose/confs/login.yml
@@ -47,6 +47,6 @@ responses:
     code: 401
     type: template
   success:
-    template: '{ "token" : "{{ stringescape .variable_actions_gentoken }}" }'
+    template: '{ "token" : "{{ escape .variable_actions_gentoken }}" }'
     code: 200
     type: template


### PR DESCRIPTION
Nothing outside this repo consumes these, so each shape has one spelling now rather than an old one kept alive beside it.

- ParseStepRef no longer strips a leading "$" from a step reference. CanonicalStepID was only ever that strip, so it is gone and its two callers use the reference as it is written.
- "stringescape" is dropped from the template FuncMap; escape is the name.
- decodeConversationMessage fails on a message type it does not recognise instead of returning (nil, nil) and having load() drop it. Resuming a thread with a message missing from the middle of it would hand the model a conversation that never happened; resolveConversation already treats a failed load as an empty thread, so the request still starts.
- PlannerConfig loses EndLookupKey and ResultTag, neither of which is read anywhere. EndValue is how a plan's ending is set.
- conversationStoragePrefix, GetFieldsForAction and the step-prefix constants describe what they do; GetFieldsForAction in particular was labelled "kept for backward compatibility" while having two live callers.