### PR TITLE
A conversation writes itself, and belongs to one request

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -35,6 +35,9 @@ func RunServer(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
+	// Conversations are written by a background writer, whose failures happen
+	// after the appending request has moved on. Without a logger they are lost.
+	storage.SetLogger(logging.GetNewLogger())
 
 	eng, err := server.New(
 		cfg.Env,

--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -26,6 +26,10 @@ type RequestContext struct {
 	availableFiles   map[string]*FileValue
 	workspace        Workspace
 	conversation     *Conversation
+	// ownsConversation records whether this request is the one that persists
+	// the thread at completion: true for a thread it created or bound, false
+	// for a caller's thread it merely joined.
+	ownsConversation bool
 
 	// tokenInput/tokenOutput accumulate LLM token usage across every model call
 	// in this request. Observability-only — not exposed to workflow templates.

--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -26,10 +26,6 @@ type RequestContext struct {
 	availableFiles   map[string]*FileValue
 	workspace        Workspace
 	conversation     *Conversation
-	// ownsConversation records whether this request is the one that persists
-	// the thread at completion: true for a thread it created or bound, false
-	// for a caller's thread it merely joined.
-	ownsConversation bool
 
 	// tokenInput/tokenOutput accumulate LLM token usage across every model call
 	// in this request. Observability-only — not exposed to workflow templates.

--- a/pkg/engine/requestctx/conversation.go
+++ b/pkg/engine/requestctx/conversation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Servflow/servflow/pkg/storage"
@@ -21,34 +22,40 @@ const conversationStoragePrefix = "agent_conversation_"
 // prompt — and because loading a log that only grows is unbounded work.
 const conversationHistoryWindow = 200
 
-// Conversation is the run-scoped message thread owned by a RequestContext.
-// Every agent action in a plan reads and appends to the SAME Conversation, so
-// the thread is the shared, mid-run-accessible record of everything the run's
-// agents have said and done. A Conversation always has an identifier and is
-// created once per request by Start (resumed from the log store when the id was
-// supplied, otherwise fresh); sub-workflows share it by pointer with the parent.
+// Conversation is the message thread of one request. Every agent action in a
+// plan reads and appends to the SAME Conversation, so the thread is the
+// mid-run-accessible record of everything that request's agents have said and
+// done. It always has an identifier and is created once per request by Start —
+// resumed from the log store when the id was supplied, otherwise fresh.
 //
-// Appends are in-memory only: the agent hot path never blocks on storage. The
-// thread is written to the log store once, at request completion (Flush).
+// A thread belongs to one request and is never handed to another: a
+// sub-workflow gets its own, named under its caller's (see
+// childConversationID), and returns a result rather than a share of the
+// caller's thread. Two requests resuming the same id each work from their own
+// copy and their appends merge in the log, which is append-only.
+//
+// Appends are written through to the log store in the background: the agent hot
+// path neither blocks on the disk nor waits for the end of the request to
+// become durable. Sync waits for what has been appended so far to be readable.
 //
 // All methods are safe for concurrent use: the per-conversation mutex is what
 // stops parallel agent actions in the same request from clobbering each other —
-// a batch of messages is appended atomically, never interleaved mid-batch.
+// a batch of messages is appended atomically, never interleaved mid-batch, and
+// it reaches the log in the order it reaches the thread.
 type Conversation struct {
 	mu       sync.Mutex
 	id       string
 	messages []ConversationMessage
-	// flushed is the number of leading messages already written to the log store:
-	// messages[flushed:] is what a Flush still has to persist. Set by load to the
-	// size of the resumed history so that history is never written back.
-	flushed int
+	// appendedHere records whether this request has contributed to the thread, as
+	// opposed to merely loading it. It is what BindConversation refuses on: those
+	// messages are already in the store under this id.
+	appendedHere bool
 }
 
 // NewConversation builds an empty conversation with the given identifier.
-// Appends go to memory; the thread is persisted when Flush is called (Start
-// arranges this at completion for the request that owns the thread). Production
-// code obtains its conversation from the RequestContext; this constructor is
-// exported for hosts that inject a thread and for tests.
+// Appends are written through to the log store under that identifier.
+// Production code obtains its conversation from the RequestContext; this
+// constructor is exported for hosts that inject a thread and for tests.
 func NewConversation(id string) *Conversation {
 	return &Conversation{
 		id:       id,
@@ -75,67 +82,59 @@ func (c *Conversation) Messages() []ConversationMessage {
 	return out
 }
 
-// Append adds messages to the in-memory thread. It is the single method through
-// which agent actions contribute to the shared conversation, and it never
-// touches storage — persistence happens once at request completion. The whole
-// batch is appended under the lock, so concurrent agents cannot interleave
-// within it. A nil/empty call is a no-op.
+// Append adds messages to the thread and queues them for the log store. It is
+// the single method through which agent actions contribute to the conversation.
+// It does not wait for the disk — what it queues is written by the log writer,
+// which reports its own failures.
+//
+// The whole batch is appended under the lock, so concurrent agents cannot
+// interleave within it, and the queueing happens under the same lock so the
+// thread's order and the log's order are the same order. A nil/empty call is a
+// no-op.
 func (c *Conversation) Append(msgs ...ConversationMessage) {
 	if c == nil || len(msgs) == 0 {
 		return
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.messages = append(c.messages, msgs...)
-	c.mu.Unlock()
+	c.appendedHere = true
+	if c.id == "" {
+		return
+	}
+	entries := make([]storage.Serializable, len(msgs))
+	for i := range msgs {
+		entries[i] = msgs[i]
+	}
+	storage.AppendToLog(conversationStoragePrefix+c.id, entries...)
 }
 
-// appended reports whether this request has added messages that are not yet in
-// the store. It is what makes rebinding a request to another thread safe to
-// refuse: those messages exist only in memory, and swapping the thread out from
-// under them would drop them.
+// appended reports whether this request has contributed to the thread rather
+// than only loading it. It is what makes rebinding to another thread safe to
+// refuse: what has been appended is already in the store under the current id,
+// and moving the request now would file the rest of the turn elsewhere.
 func (c *Conversation) appended() bool {
 	if c == nil {
 		return false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return len(c.messages) > c.flushed
+	return c.appendedHere
 }
 
-// flush writes the messages appended since the last flush to the log store and
-// advances the high-water mark, so a resumed thread only ever persists what the
-// current request added.
-func (c *Conversation) flush() error {
-	c.mu.Lock()
-	if c.id == "" || c.flushed >= len(c.messages) {
-		c.mu.Unlock()
-		return nil
-	}
-	pending := c.messages[c.flushed:]
-	batch := make([]storage.Serializable, len(pending))
-	for i := range pending {
-		batch[i] = pending[i]
-	}
-	high := len(c.messages)
-	id := c.id
-	c.mu.Unlock()
-
-	if err := storage.WriteToLog(conversationStoragePrefix+id, batch); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	c.flushed = high
-	c.mu.Unlock()
-	return nil
-}
-
-// Flush writes the messages added during this request to the log store. Called
-// once, at request completion, by the request that owns the conversation.
-func (c *Conversation) Flush() error {
+// Sync waits for everything appended to this thread so far to be readable, and
+// reports whether it is.
+//
+// Appends are written in the background, so a caller that is about to let
+// something else read the thread — the next turn of a chat this one has been
+// holding a lock against — waits here first. Nothing else needs to: a thread is
+// durable shortly after it is spoken, with or without this.
+func (c *Conversation) Sync() error {
 	if c == nil {
 		return nil
 	}
-	return c.flush()
+	return storage.SyncLog()
 }
 
 // load prepends the stored thread for this conversation id — its most recent
@@ -157,9 +156,9 @@ func (c *Conversation) load() error {
 		}
 		c.messages = append(c.messages, msg)
 	}
-	// Resumed messages are already in the store; the sync must only write
-	// messages appended after this point, never re-persist the loaded history.
-	c.flushed = len(c.messages)
+	// Loaded messages come from the store and go back into the thread directly,
+	// never through Append — re-queueing them would write the history a second
+	// time on every resume.
 	return nil
 }
 
@@ -188,29 +187,43 @@ func decodeConversationMessage(data []byte) (any, error) {
 	}
 }
 
-// resolveConversation builds the Conversation for a request from its Options and
-// reports whether this request OWNS it (must flush it at completion). A child
-// request with no explicit ConversationID joins its parent's thread by pointer
-// and does NOT own it — the parent, which completes last, persists the thread
-// for both. Otherwise a fresh thread is created — always with an
-// identifier (generated when none was supplied). A supplied id is resumed from
-// the store best-effort: a load failure yields an empty thread rather than
-// failing request start.
-func resolveConversation(opts Options) (conv *Conversation, owned bool) {
-	if opts.ConversationID == "" && opts.Parent != nil {
-		if pc := opts.Parent.Conversation(); pc != nil {
-			return pc, false
+// resolveConversation builds the Conversation for a request from its Options.
+// Every request gets its own thread, always with an identifier:
+//
+//   - a supplied id resumes that thread from the store, best-effort — a load
+//     failure yields an empty thread rather than failing request start;
+//   - a child request gets a fresh thread named under its caller's, so a
+//     sub-workflow speaks into its own record and hands back only its result;
+//   - anything else gets a fresh thread under a generated id.
+func resolveConversation(opts Options) *Conversation {
+	if opts.ConversationID != "" {
+		conv := NewConversation(opts.ConversationID)
+		_ = conv.load()
+		return conv
+	}
+	if opts.Parent != nil {
+		if parent := opts.Parent.Conversation(); parent != nil {
+			return NewConversation(childConversationID(parent.ID()))
 		}
 	}
-	id := opts.ConversationID
-	if id == "" {
-		id = fmt.Sprintf("conversation_%d", time.Now().UnixNano())
-	}
-	conv = NewConversation(id)
-	if opts.ConversationID != "" {
-		_ = conv.load()
-	}
-	return conv, true
+	return NewConversation(fmt.Sprintf("conversation_%d", time.Now().UnixNano()))
+}
+
+// childSuffix numbers the threads created under a parent. It is a counter
+// rather than a timestamp because a plan can start two sub-workflows in
+// parallel, and two threads created in the same nanosecond must not share a
+// name.
+var childSuffix atomic.Uint64
+
+// childConversationID names a child request's thread under its parent's.
+//
+// The lineage is in the id so a sub-workflow's thread is never loose in the
+// store: everything said under a chat, however deep the workflow nesting, is
+// reachable from that chat's id by prefix. The separator is deliberately not
+// the ":" the log store builds keys with, so loading a parent cannot pick up
+// its children's messages.
+func childConversationID(parentID string) string {
+	return fmt.Sprintf("%s/sub_%d", parentID, childSuffix.Add(1))
 }
 
 // Conversation returns the request's conversation thread. It is never nil for a
@@ -222,43 +235,33 @@ func (rc *RequestContext) Conversation() *Conversation {
 	return rc.conversation
 }
 
-// setConversation installs the thread for this request and records whether this
-// request is the one that persists it. Used by Start and BindConversation.
-func (rc *RequestContext) setConversation(c *Conversation, owned bool) {
+// setConversation installs the thread for this request. Used by Start and
+// BindConversation.
+func (rc *RequestContext) setConversation(c *Conversation) {
 	rc.Lock()
 	defer rc.Unlock()
 	rc.conversation = c
-	rc.ownsConversation = owned
-}
-
-// conversationToPersist returns the thread this request must write at
-// completion, and whether there is one: a request that joined its caller's
-// thread contributes to it but does not persist it — the caller, which
-// completes last, does.
-func (rc *RequestContext) conversationToPersist() (*Conversation, bool) {
-	rc.Lock()
-	defer rc.Unlock()
-	return rc.conversation, rc.ownsConversation && rc.conversation != nil
 }
 
 // BindConversation puts this request on the thread named by id, loaded from the
-// store, and makes the request responsible for persisting it.
+// store.
 //
 // It exists for senders that carry their own notion of a thread and no way to
 // state it as a request header: a Telegram chat is a conversation, but a
 // delivery from Telegram says so only in its body, and only once the delivery
 // has been authenticated. So an entry handler binds after it knows what it is
 // talking to, and the thread the request started on — created by Start, empty,
-// never appended to, never flushed — is dropped without a trace.
+// never spoken into — is dropped without a trace.
 //
-// It must be called before anything appends to the current thread: those
-// messages live only in memory until completion, and binding would discard
-// them. That is an error, not a silent loss.
+// It must be called before anything appends to the current thread: what has
+// been appended is already in the store under the thread's own id, so binding
+// now would leave one turn split across two threads. That is an error, not a
+// silent misfiling.
 func (rc *RequestContext) BindConversation(id string) error {
 	if id == "" {
 		return errors.New("conversation id cannot be empty")
 	}
-	current, _ := rc.conversationToPersist()
+	current := rc.Conversation()
 	if current.appended() {
 		return fmt.Errorf("cannot bind conversation %q: this request has already appended to %q",
 			id, current.ID())
@@ -271,6 +274,6 @@ func (rc *RequestContext) BindConversation(id string) error {
 	if err := conv.load(); err != nil {
 		return fmt.Errorf("loading conversation %q: %w", id, err)
 	}
-	rc.setConversation(conv, true)
+	rc.setConversation(conv)
 	return nil
 }

--- a/pkg/engine/requestctx/conversation.go
+++ b/pkg/engine/requestctx/conversation.go
@@ -2,6 +2,7 @@ package requestctx
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -12,6 +13,13 @@ import (
 // conversationStoragePrefix namespaces persisted conversation messages in the
 // log store; the conversation id follows it to key one thread.
 const conversationStoragePrefix = "agent_conversation_"
+
+// conversationHistoryWindow is how much of a thread a resumed request starts
+// with: its most recent messages, oldest first. It is a window rather than the
+// whole thread because a thread is fed to the model on every turn — a chat
+// that has run for months would otherwise put its entire past into each
+// prompt — and because loading a log that only grows is unbounded work.
+const conversationHistoryWindow = 200
 
 // Conversation is the run-scoped message thread owned by a RequestContext.
 // Every agent action in a plan reads and appends to the SAME Conversation, so
@@ -81,6 +89,19 @@ func (c *Conversation) Append(msgs ...ConversationMessage) {
 	c.mu.Unlock()
 }
 
+// appended reports whether this request has added messages that are not yet in
+// the store. It is what makes rebinding a request to another thread safe to
+// refuse: those messages exist only in memory, and swapping the thread out from
+// under them would drop them.
+func (c *Conversation) appended() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.messages) > c.flushed
+}
+
 // flush writes the messages appended since the last flush to the log store and
 // advances the high-water mark, so a resumed thread only ever persists what the
 // current request added.
@@ -117,12 +138,13 @@ func (c *Conversation) Flush() error {
 	return c.flush()
 }
 
-// load prepends the stored thread for this conversation id, so a resumed run
-// starts with the existing history in front of anything it appends. It is called
-// by resolveConversation at construction — before any agent can append — so the
-// loaded messages are necessarily the leading ones.
+// load prepends the stored thread for this conversation id — its most recent
+// conversationHistoryWindow messages — so a resumed run starts with the
+// existing history in front of anything it appends. It is called before any
+// agent can append, so the loaded messages are necessarily the leading ones.
 func (c *Conversation) load() error {
-	entries, err := storage.GetLogEntriesByPrefix(conversationStoragePrefix+c.id, decodeConversationMessage)
+	entries, err := storage.GetLogEntriesByPrefix(
+		conversationStoragePrefix+c.id, conversationHistoryWindow, decodeConversationMessage)
 	if err != nil {
 		return err
 	}
@@ -200,9 +222,55 @@ func (rc *RequestContext) Conversation() *Conversation {
 	return rc.conversation
 }
 
-// setConversation installs the thread for this request. Used by Start.
-func (rc *RequestContext) setConversation(c *Conversation) {
+// setConversation installs the thread for this request and records whether this
+// request is the one that persists it. Used by Start and BindConversation.
+func (rc *RequestContext) setConversation(c *Conversation, owned bool) {
 	rc.Lock()
 	defer rc.Unlock()
 	rc.conversation = c
+	rc.ownsConversation = owned
+}
+
+// conversationToPersist returns the thread this request must write at
+// completion, and whether there is one: a request that joined its caller's
+// thread contributes to it but does not persist it — the caller, which
+// completes last, does.
+func (rc *RequestContext) conversationToPersist() (*Conversation, bool) {
+	rc.Lock()
+	defer rc.Unlock()
+	return rc.conversation, rc.ownsConversation && rc.conversation != nil
+}
+
+// BindConversation puts this request on the thread named by id, loaded from the
+// store, and makes the request responsible for persisting it.
+//
+// It exists for senders that carry their own notion of a thread and no way to
+// state it as a request header: a Telegram chat is a conversation, but a
+// delivery from Telegram says so only in its body, and only once the delivery
+// has been authenticated. So an entry handler binds after it knows what it is
+// talking to, and the thread the request started on — created by Start, empty,
+// never appended to, never flushed — is dropped without a trace.
+//
+// It must be called before anything appends to the current thread: those
+// messages live only in memory until completion, and binding would discard
+// them. That is an error, not a silent loss.
+func (rc *RequestContext) BindConversation(id string) error {
+	if id == "" {
+		return errors.New("conversation id cannot be empty")
+	}
+	current, _ := rc.conversationToPersist()
+	if current.appended() {
+		return fmt.Errorf("cannot bind conversation %q: this request has already appended to %q",
+			id, current.ID())
+	}
+	if current != nil && current.ID() == id {
+		return nil
+	}
+
+	conv := NewConversation(id)
+	if err := conv.load(); err != nil {
+		return fmt.Errorf("loading conversation %q: %w", id, err)
+	}
+	rc.setConversation(conv, true)
+	return nil
 }

--- a/pkg/engine/requestctx/conversation_test.go
+++ b/pkg/engine/requestctx/conversation_test.go
@@ -195,3 +195,70 @@ func TestConversation_ImageNotPersisted(t *testing.T) {
 		t.Fatalf("resumed message renders as %v/%q, want text/%q", outputType, content, got.Text)
 	}
 }
+
+// TestBindConversation_PutsTheRequestOnAnotherThread verifies what an entry
+// handler binding to a sender-named thread relies on: the bound thread's stored
+// history is loaded, and it is the bound thread — not the one Start created —
+// that the completion hook persists.
+func TestBindConversation_PutsTheRequestOnAnotherThread(t *testing.T) {
+	const bound = "test-bind-target"
+
+	// A thread with a past, as a previous request would have left it.
+	previous := NewConversation(bound)
+	previous.Append(textMsg("said before"))
+	if err := previous.flush(); err != nil {
+		t.Fatalf("seeding the thread: %v", err)
+	}
+
+	// A request that starts with no id of its own, as a delivery carrying no
+	// conversation header does.
+	ctx, rc := Start(context.Background(), Options{})
+	started := FromContextConversation(t, ctx)
+
+	if err := rc.BindConversation(bound); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	conv := rc.Conversation()
+	if conv.ID() != bound {
+		t.Fatalf("conversation id = %q, want %q", conv.ID(), bound)
+	}
+	if got := contents(conv.Messages()); len(got) != 1 || got[0] != "said before" {
+		t.Fatalf("bound thread contents = %v, want [said before]", got)
+	}
+
+	conv.Append(textMsg("said now"))
+	rc.Done()
+
+	after := NewConversation(bound)
+	if err := after.load(); err != nil {
+		t.Fatalf("post-completion load: %v", err)
+	}
+	if got := contents(after.Messages()); len(got) != 2 || got[1] != "said now" {
+		t.Fatalf("persisted contents = %v, want [said before said now]", got)
+	}
+
+	// The thread the request started on was never appended to, so it left
+	// nothing behind.
+	orphan := NewConversation(started.ID())
+	if err := orphan.load(); err != nil {
+		t.Fatalf("orphan load: %v", err)
+	}
+	if n := len(orphan.Messages()); n != 0 {
+		t.Fatalf("the dropped thread persisted %d messages, want 0", n)
+	}
+}
+
+// TestBindConversation_RefusesAfterAnAppend verifies the guard that keeps
+// binding from discarding messages: they live only in memory until completion.
+func TestBindConversation_RefusesAfterAnAppend(t *testing.T) {
+	ctx, rc := Start(context.Background(), Options{})
+	FromContextConversation(t, ctx).Append(textMsg("already said"))
+
+	if err := rc.BindConversation("test-bind-too-late"); err == nil {
+		t.Fatal("bind after an append succeeded, want an error")
+	}
+	if err := rc.BindConversation(""); err == nil {
+		t.Fatal("bind to an empty id succeeded, want an error")
+	}
+}

--- a/pkg/engine/requestctx/conversation_test.go
+++ b/pkg/engine/requestctx/conversation_test.go
@@ -38,34 +38,22 @@ func contents(msgs []ConversationMessage) []string {
 	return out
 }
 
-// TestConversation_IncrementalFlushAndResume verifies that (a) flush only writes
-// the tail appended since the previous flush, and (b) resuming an id loads the
-// full thread exactly once — the load-time high-water mark prevents the resumed
-// history from being re-persisted on the next flush.
-func TestConversation_IncrementalFlushAndResume(t *testing.T) {
-	const id = "test-sync-incremental"
+// TestConversation_WritesThroughAndResumes verifies the thread's whole
+// persistence contract: what is appended is written as it is said, a resume
+// loads it once and in order, and a resumed thread that speaks again does not
+// write its loaded history back.
+func TestConversation_WritesThroughAndResumes(t *testing.T) {
+	const id = "test-write-through"
 
 	conv := NewConversation(id)
 	conv.Append(textMsg("one"), textMsg("two"))
-	if err := conv.flush(); err != nil {
-		t.Fatalf("first flush: %v", err)
-	}
-	if conv.flushed != 2 {
-		t.Fatalf("flushed = %d, want 2", conv.flushed)
+	if err := conv.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
 	}
 
-	// Second flush writes only the new tail; the first two are not re-written.
 	conv.Append(textMsg("three"))
-	if err := conv.flush(); err != nil {
-		t.Fatalf("second flush: %v", err)
-	}
-	if conv.flushed != 3 {
-		t.Fatalf("flushed = %d, want 3", conv.flushed)
-	}
-
-	// A no-op flush (nothing pending) must not error or advance.
-	if err := conv.flush(); err != nil {
-		t.Fatalf("noop flush: %v", err)
+	if err := conv.Sync(); err != nil {
+		t.Fatalf("second sync: %v", err)
 	}
 
 	// Resume: a fresh conversation loads the whole thread, once, in order.
@@ -83,52 +71,102 @@ func TestConversation_IncrementalFlushAndResume(t *testing.T) {
 			t.Fatalf("resumed[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
 		}
 	}
-	// Loaded history is already persisted: flushed must equal the loaded count so
-	// the next flush is a no-op, not a duplicate write.
-	if resumed.flushed != len(want) {
-		t.Fatalf("resumed.flushed = %d, want %d", resumed.flushed, len(want))
-	}
-	if err := resumed.flush(); err != nil {
-		t.Fatalf("post-resume flush: %v", err)
-	}
 
-	// Loading again must still see exactly three (no duplication introduced).
+	// The resumed thread speaks: only the new message is added to the store.
+	resumed.Append(textMsg("four"))
+	if err := resumed.Sync(); err != nil {
+		t.Fatalf("post-resume sync: %v", err)
+	}
 	check := NewConversation(id)
 	if err := check.load(); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if n := len(check.Messages()); n != 3 {
-		t.Fatalf("reload count = %d, want 3", n)
+	if got := contents(check.Messages()); len(got) != 4 {
+		t.Fatalf("reload contents = %v, want four messages with no duplicated history", got)
 	}
 }
 
-// TestConversation_FlushAtRequestCompletion verifies the wiring Start relies on:
-// a conversation accumulates in memory and is persisted by the completion hook,
-// with nothing written before it fires.
-func TestConversation_FlushAtRequestCompletion(t *testing.T) {
-	const id = "test-flush-on-complete"
+// TestConversation_ReadableBeforeTheRequestCompletes is what a chat handing one
+// turn to the next depends on: a message is durable once it has been said and
+// synced, not at the end of the request that said it.
+func TestConversation_ReadableBeforeTheRequestCompletes(t *testing.T) {
+	const id = "test-readable-mid-request"
 
 	ctx, rc := Start(context.Background(), Options{ConversationID: id})
 	conv := FromContextConversation(t, ctx)
 	conv.Append(textMsg("during the request"))
-
-	// Nothing is persisted until the request completes.
-	before := NewConversation(id)
-	if err := before.load(); err != nil {
-		t.Fatalf("pre-completion load: %v", err)
-	}
-	if n := len(before.Messages()); n != 0 {
-		t.Fatalf("persisted %d messages before completion, want 0", n)
+	if err := conv.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
 	}
 
-	rc.Done() // main flow finished; no child flows → completes immediately
+	during := NewConversation(id)
+	if err := during.load(); err != nil {
+		t.Fatalf("mid-request load: %v", err)
+	}
+	if got := contents(during.Messages()); len(got) != 1 || got[0] != "during the request" {
+		t.Fatalf("mid-request contents = %v, want [during the request]", got)
+	}
+
+	// Completing the request adds nothing: the thread was already written.
+	rc.Done()
 
 	after := NewConversation(id)
 	if err := after.load(); err != nil {
 		t.Fatalf("post-completion load: %v", err)
 	}
-	if got := contents(after.Messages()); len(got) != 1 || got[0] != "during the request" {
-		t.Fatalf("persisted contents = %v, want [during the request]", got)
+	if got := contents(after.Messages()); len(got) != 1 {
+		t.Fatalf("post-completion contents = %v, want the one message, written once", got)
+	}
+}
+
+// TestConversation_SubRunKeepsItsOwnThread verifies the isolation a workflow
+// tool relies on: a child request speaks into its own thread, named under its
+// caller's, and the caller's thread is untouched by it.
+func TestConversation_SubRunKeepsItsOwnThread(t *testing.T) {
+	const id = "test-parent-thread"
+
+	parentCtx, parent := Start(context.Background(), Options{ConversationID: id})
+	FromContextConversation(t, parentCtx).Append(textMsg("caller asked"))
+
+	_, child := Start(parentCtx, Options{ID: "child", Parent: parent})
+	childConv := child.Conversation()
+	if childConv == nil {
+		t.Fatal("child request has no conversation")
+	}
+	if childConv == parent.Conversation() {
+		t.Fatal("child request shares its caller's thread")
+	}
+	if !strings.HasPrefix(childConv.ID(), id+"/") {
+		t.Fatalf("child thread id = %q, want it named under %q", childConv.ID(), id)
+	}
+	if !strings.HasPrefix(child.ID(), parent.ID()+"/") {
+		t.Fatalf("child request id = %q, want it named under %q", child.ID(), parent.ID())
+	}
+
+	childConv.Append(textMsg("sub-run worked"))
+	if err := childConv.Sync(); err != nil {
+		t.Fatalf("child sync: %v", err)
+	}
+	child.Done()
+	parent.Done()
+
+	// The caller's thread holds only what the caller said. What the sub-run said
+	// reaches the caller as the result of the call, not as a share of its thread.
+	after := NewConversation(id)
+	if err := after.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := contents(after.Messages()); len(got) != 1 || got[0] != "caller asked" {
+		t.Fatalf("caller's thread = %v, want [caller asked]", got)
+	}
+
+	// The child's own thread is in the store, under the caller's id.
+	sub := NewConversation(childConv.ID())
+	if err := sub.load(); err != nil {
+		t.Fatalf("sub load: %v", err)
+	}
+	if got := contents(sub.Messages()); len(got) != 1 || got[0] != "sub-run worked" {
+		t.Fatalf("sub-run thread = %v, want [sub-run worked]", got)
 	}
 }
 
@@ -149,8 +187,8 @@ func TestConversation_ImageNotPersisted(t *testing.T) {
 
 	conv := NewConversation(id)
 	conv.Append(img)
-	if err := conv.flush(); err != nil {
-		t.Fatalf("flush: %v", err)
+	if err := conv.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
 	}
 
 	// The live message is untouched — the model still gets the real image.
@@ -198,15 +236,15 @@ func TestConversation_ImageNotPersisted(t *testing.T) {
 
 // TestBindConversation_PutsTheRequestOnAnotherThread verifies what an entry
 // handler binding to a sender-named thread relies on: the bound thread's stored
-// history is loaded, and it is the bound thread — not the one Start created —
-// that the completion hook persists.
+// history is loaded, and what the request goes on to say lands on that thread
+// rather than the one Start created.
 func TestBindConversation_PutsTheRequestOnAnotherThread(t *testing.T) {
 	const bound = "test-bind-target"
 
 	// A thread with a past, as a previous request would have left it.
 	previous := NewConversation(bound)
 	previous.Append(textMsg("said before"))
-	if err := previous.flush(); err != nil {
+	if err := previous.Sync(); err != nil {
 		t.Fatalf("seeding the thread: %v", err)
 	}
 
@@ -228,6 +266,9 @@ func TestBindConversation_PutsTheRequestOnAnotherThread(t *testing.T) {
 	}
 
 	conv.Append(textMsg("said now"))
+	if err := conv.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
 	rc.Done()
 
 	after := NewConversation(bound)

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -55,16 +55,17 @@ type Options struct {
 	// AddRequestTemplateFunctions for the seeded funcs.
 	TemplateFuncsExclusive bool
 	// Parent links a sub-workflow to its caller: secrets are shared, the
-	// parent's workspace is inherited, and this request registers as a child
-	// flow of the parent, so the parent's total time transitively covers this
-	// request's entire lifetime. A child with no explicit ConversationID also
-	// joins the parent's conversation thread.
+	// parent's workspace is inherited, the request id is derived from the
+	// parent's, and this request registers as a child flow of the parent, so the
+	// parent's total time transitively covers this request's entire lifetime. A
+	// child with no explicit ConversationID gets its own thread, named under its
+	// parent's — threads are never shared between requests.
 	Parent *RequestContext
-	// ConversationID selects the run's conversation thread. When set, the thread
-	// is resumed from the log store (empty if new) so a later request with the
-	// same id continues it. When empty, a fresh thread with a generated id is
-	// created. Either way the thread is synced to the log store in the background;
-	// agents read and append in memory.
+	// ConversationID selects the request's conversation thread. When set, the
+	// thread is resumed from the log store (empty if new) so a later request with
+	// the same id continues it. When empty, a fresh thread with a generated id is
+	// created. Either way, what agents append is written through to the log store
+	// in the background.
 	ConversationID string
 }
 
@@ -75,6 +76,11 @@ func Start(ctx context.Context, opts Options) (context.Context, *RequestContext)
 	id := opts.ID
 	if id == "" {
 		id = fmt.Sprintf("request_%d", time.Now().UnixNano())
+	}
+	if opts.Parent != nil {
+		// A child's id carries its caller's, so a sub-workflow's request and its
+		// thread are both traceable to the run that started them.
+		id = opts.Parent.ID() + "/" + id
 	}
 	rc := NewRequestContext(id)
 	rc.spanAttrs = append(append([]attribute.KeyValue{}, opts.SpanAttributes...),
@@ -95,29 +101,7 @@ func Start(ctx context.Context, opts Options) (context.Context, *RequestContext)
 			rc.SetWorkspace(ws)
 		}
 	}
-	conv, owned := resolveConversation(opts)
-	rc.setConversation(conv, owned)
-	// The conversation lives in memory for the request and is written once, at
-	// completion — which is after the response is sent AND after child flows
-	// drain, so a sub-workflow's messages are included and the client waits on
-	// nothing. Only the owning request flushes; adopted threads are persisted by
-	// the request that created them.
-	//
-	// The thread is read at completion rather than captured here, because it is
-	// not necessarily the one Start created: an entry handler may bind the
-	// request to a thread named by its sender (see BindConversation), and it is
-	// whatever the request ended up on that has to be written.
-	flushLogger := opts.Logger
-	rc.RegisterOnCompleteHook(func() {
-		conv, persist := rc.conversationToPersist()
-		if !persist {
-			return
-		}
-		if err := conv.Flush(); err != nil && flushLogger != nil {
-			flushLogger.Warn("failed to persist conversation",
-				zap.String("conversation_id", conv.ID()), zap.Error(err))
-		}
-	})
+	rc.setConversation(resolveConversation(opts))
 	ctx = WithAggregationContext(ctx, rc)
 	if opts.Logger != nil {
 		l := WrapWithScrubber(opts.Logger.With(zap.String("request_id", id)), rc)

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -96,21 +96,28 @@ func Start(ctx context.Context, opts Options) (context.Context, *RequestContext)
 		}
 	}
 	conv, owned := resolveConversation(opts)
-	rc.setConversation(conv)
-	if owned {
-		// The conversation lives in memory for the request and is written once, at
-		// completion — which is after the response is sent AND after child flows
-		// drain, so a sub-workflow's messages are included and the client waits on
-		// nothing. Only the owning request flushes; adopted threads are persisted
-		// by the request that created them.
-		flushLogger := opts.Logger
-		rc.RegisterOnCompleteHook(func() {
-			if err := conv.Flush(); err != nil && flushLogger != nil {
-				flushLogger.Warn("failed to persist conversation",
-					zap.String("conversation_id", conv.ID()), zap.Error(err))
-			}
-		})
-	}
+	rc.setConversation(conv, owned)
+	// The conversation lives in memory for the request and is written once, at
+	// completion — which is after the response is sent AND after child flows
+	// drain, so a sub-workflow's messages are included and the client waits on
+	// nothing. Only the owning request flushes; adopted threads are persisted by
+	// the request that created them.
+	//
+	// The thread is read at completion rather than captured here, because it is
+	// not necessarily the one Start created: an entry handler may bind the
+	// request to a thread named by its sender (see BindConversation), and it is
+	// whatever the request ended up on that has to be written.
+	flushLogger := opts.Logger
+	rc.RegisterOnCompleteHook(func() {
+		conv, persist := rc.conversationToPersist()
+		if !persist {
+			return
+		}
+		if err := conv.Flush(); err != nil && flushLogger != nil {
+			flushLogger.Warn("failed to persist conversation",
+				zap.String("conversation_id", conv.ID()), zap.Error(err))
+		}
+	})
 	ctx = WithAggregationContext(ctx, rc)
 	if opts.Logger != nil {
 		l := WrapWithScrubber(opts.Logger.With(zap.String("request_id", id)), rc)

--- a/pkg/storage/logwriter.go
+++ b/pkg/storage/logwriter.go
@@ -1,0 +1,191 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"go.uber.org/zap"
+)
+
+// logQueueSize is how many appends may be waiting on the writer before an
+// append blocks. Blocking at the limit is the intended behaviour: it bounds the
+// memory the queue can hold and pushes back on a producer outrunning the disk.
+// With batched commits the queue only fills if badger itself has stalled.
+const logQueueSize = 1024
+
+// logBatchSize caps how many queued appends one commit takes, so a producer
+// that never pauses cannot grow a batch without bound.
+const logBatchSize = 256
+
+// logWrite is one queued append, or — when done is non-nil — a barrier: the
+// writer closes done once everything queued ahead of it is committed, which is
+// what lets a caller wait for its own appends to become readable.
+type logWrite struct {
+	prefix string
+	value  Serializable
+	done   chan error
+}
+
+// logWriter serialises every append to the log store onto one goroutine.
+//
+// A single writer is what makes the log's ordering guarantees cheap. Keys are
+// assigned from one counter by one goroutine, so no two entries can collide or
+// land out of order however many requests are appending at once, and whatever
+// piled up while the last commit was in flight is written as a single batch.
+type logWriter struct {
+	queue chan logWrite
+	seq   uint64 // writer-owned: only run() touches it, so it needs no lock
+}
+
+var (
+	writer     *logWriter
+	writerOnce sync.Once
+)
+
+// logQueue returns the process's log writer, starting it on first use.
+func logQueue() *logWriter {
+	writerOnce.Do(func() {
+		writer = &logWriter{queue: make(chan logWrite, logQueueSize)}
+		go writer.run()
+	})
+	return writer
+}
+
+// writerLogger is where the writer reports failures. A queued append is written
+// long after the call that made it returned, so this is the only place those
+// errors can surface.
+var writerLogger atomic.Pointer[zap.Logger]
+
+// SetLogger installs the logger the background log writer reports failures to.
+// Until a host calls this, failures are discarded.
+func SetLogger(l *zap.Logger) {
+	writerLogger.Store(l)
+}
+
+func writerLog() *zap.Logger {
+	if l := writerLogger.Load(); l != nil {
+		return l
+	}
+	return zap.NewNop()
+}
+
+// AppendToLog queues entries to be written under prefix and returns without
+// waiting for the disk.
+//
+// Entries appear in the log in the order the appends completed, and become
+// readable once the writer has committed them — SyncLog waits for exactly that.
+// Nothing is reported back here: a failure to serialise or write happens after
+// this call has returned, and goes to the logger installed with SetLogger.
+func AppendToLog(prefix string, values ...Serializable) {
+	if len(values) == 0 {
+		return
+	}
+	if prefix == "" {
+		writerLog().Error("dropping log entries appended with no prefix",
+			zap.Int("entries", len(values)))
+		return
+	}
+	q := logQueue()
+	for _, value := range values {
+		q.queue <- logWrite{prefix: prefix, value: value}
+	}
+}
+
+// SyncLog waits for every append queued before the call to be committed, and
+// reports whether they were.
+//
+// It is for callers that must be certain a reader will see what they wrote —
+// one turn of a conversation handing over to the next turn on the same thread.
+// Ordinary appends never wait.
+func SyncLog() error {
+	done := make(chan error, 1)
+	logQueue().queue <- logWrite{done: done}
+	return <-done
+}
+
+// run drains the queue for the life of the process, committing each batch it
+// collects. It takes whatever is already queued behind the entry that woke it,
+// so a burst of appends costs one commit rather than one per message.
+func (w *logWriter) run() {
+	for first := range w.queue {
+		batch := append(make([]logWrite, 0, logBatchSize), first)
+	drain:
+		for len(batch) < logBatchSize {
+			select {
+			case next := <-w.queue:
+				batch = append(batch, next)
+			default:
+				break drain
+			}
+		}
+		w.commit(batch)
+	}
+}
+
+// commit writes a batch's entries, then releases the barriers it carries. The
+// release happens after the write, which is the guarantee SyncLog sells.
+func (w *logWriter) commit(batch []logWrite) {
+	err := w.write(batch)
+	if err != nil {
+		writerLog().Error("failed to write queued log entries",
+			zap.Int("batch", len(batch)), zap.Error(err))
+	}
+	for _, entry := range batch {
+		if entry.done == nil {
+			continue
+		}
+		if err != nil {
+			entry.done <- err
+		}
+		close(entry.done)
+	}
+}
+
+// write commits a batch's entries in one badger batch. A batch of nothing but
+// barriers writes nothing — a sync on an idle queue must not open the store.
+func (w *logWriter) write(batch []logWrite) error {
+	pending := make([]logWrite, 0, len(batch))
+	for _, entry := range batch {
+		if entry.done == nil {
+			pending = append(pending, entry)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	_, err := withRetryOnClose(func(db *badger.DB) (struct{}, error) {
+		wb := db.NewWriteBatch()
+		defer wb.Cancel()
+		for _, entry := range pending {
+			value, err := entry.value.Serialize()
+			if err != nil {
+				return struct{}{}, fmt.Errorf("serialise entry for %q: %w", entry.prefix, err)
+			}
+			if err := wb.Set(w.nextKey(entry.prefix), value); err != nil {
+				return struct{}{}, err
+			}
+		}
+		return struct{}{}, wb.Flush()
+	})
+	return err
+}
+
+// nextKey builds the storage key for one entry: the log's prefix, the write
+// time, and a counter.
+//
+// Entries are read back by lexicographic range scan, so a key has to sort the
+// way the log was written. The timestamp holds that order across restarts, and
+// the counter separates entries written within the same nanosecond — which a
+// timestamp alone does not: two appends in one tick produced the same key, and
+// the second silently replaced the first. Both parts are fixed width so string
+// order and numeric order agree.
+func (w *logWriter) nextKey(prefix string) []byte {
+	w.seq++
+	return []byte(fmt.Sprintf("%s:%s:%019d-%010d",
+		servflowPrefix, strings.Trim(prefix, ":"), time.Now().UnixNano(), w.seq))
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,9 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/dgraph-io/badger/v4"
 )
@@ -98,6 +96,13 @@ type Serializable interface {
 }
 
 func (c *Client) Close() error {
+	// Queued appends are still in memory and are written by another goroutine,
+	// which would find the store shut under it. Drain before closing — taken
+	// before the lock, because the writer needs the client to commit.
+	if err := SyncLog(); err != nil {
+		return err
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -108,29 +113,6 @@ func (c *Client) Close() error {
 	err := c.db.Close()
 	c.db = nil
 	return err
-}
-
-func WriteToLog(key string, value []Serializable) error {
-	for _, v := range value {
-		b, err := v.Serialize()
-		if err != nil {
-			return err
-		}
-
-		ts := time.Now().UnixNano()
-		k := []byte(fmt.Sprintf("%s:%s:%d", servflowPrefix, strings.Trim(key, ":"), ts))
-
-		_, err = withRetryOnClose(func(db *badger.DB) (struct{}, error) {
-			err := db.Update(func(txn *badger.Txn) error {
-				return txn.Set(k, b)
-			})
-			return struct{}{}, err
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // GetLogEntriesByPrefix returns the most recent limit entries written under

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -133,23 +133,41 @@ func WriteToLog(key string, value []Serializable) error {
 	return nil
 }
 
-const maxSIze = 50
-
-func GetLogEntriesByPrefix(prefix string, deserializeFunc func([]byte) (any, error)) ([]any, error) {
+// GetLogEntriesByPrefix returns the most recent limit entries written under
+// prefix, oldest first.
+//
+// Entries are keyed by write time, so "most recent" is the tail of the range:
+// the scan runs backwards from the end of the prefix and stops once it has
+// limit of them, then reverses what it collected so callers read a log in the
+// order it happened. A thread far longer than limit therefore costs the same
+// as a short one, and what a caller sees is its latest state rather than its
+// first — which is what a conversation resuming after months of use needs.
+//
+// limit is the caller's window and must be positive: an unbounded read of a
+// log that only grows is never what a caller wants.
+func GetLogEntriesByPrefix(prefix string, limit int, deserializeFunc func([]byte) (any, error)) ([]any, error) {
 	if prefix == "" {
 		return nil, errors.New("prefix cannot be empty")
+	}
+	if limit <= 0 {
+		return nil, errors.New("limit must be positive")
 	}
 	bPrefix := []byte(fmt.Sprintf("%s:%s:", servflowPrefix, prefix))
 
 	return withRetryOnClose(func(db *badger.DB) ([]any, error) {
-		result := make([]any, 0)
+		result := make([]any, 0, limit)
 		err := db.View(func(txn *badger.Txn) error {
 			opts := badger.DefaultIteratorOptions
 			opts.PrefetchSize = 10
+			opts.Reverse = true
 			it := txn.NewIterator(opts)
 			defer it.Close()
-			for it.Seek(bPrefix); it.ValidForPrefix(bPrefix); it.Next() {
-				if len(result) >= maxSIze {
+
+			// A reverse seek lands on the largest key at or below its argument,
+			// so it has to start above every key in the range: 0xFF sorts after
+			// any byte a timestamp suffix can hold.
+			for it.Seek(append(bPrefix, 0xFF)); it.ValidForPrefix(bPrefix); it.Next() {
+				if len(result) >= limit {
 					return nil
 				}
 
@@ -165,7 +183,13 @@ func GetLogEntriesByPrefix(prefix string, deserializeFunc func([]byte) (any, err
 			}
 			return nil
 		})
-		return result, err
+		if err != nil {
+			return nil, err
+		}
+		for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+			result[i], result[j] = result[j], result[i]
+		}
+		return result, nil
 	})
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -50,8 +50,8 @@ func TestWriteAndGetEntries(t *testing.T) {
 			&jsonSerializable{Topic: "topic2", Message: "message3"},
 		}
 
-		err := WriteToLog("conversations", entries)
-		require.NoError(t, err)
+		AppendToLog("conversations", entries...)
+		require.NoError(t, SyncLog())
 
 		gotten, err := GetLogEntriesByPrefix("conversations", 10, decodeJSONSerializable)
 		require.NoError(t, err)
@@ -69,7 +69,8 @@ func TestWriteAndGetEntries(t *testing.T) {
 		for i := 1; i <= 6; i++ {
 			entries = append(entries, &jsonSerializable{Topic: "windowed", Message: fmt.Sprintf("message%d", i)})
 		}
-		require.NoError(t, WriteToLog("windowed", entries))
+		AppendToLog("windowed", entries...)
+		require.NoError(t, SyncLog())
 
 		gotten, err := GetLogEntriesByPrefix("windowed", 2, decodeJSONSerializable)
 		require.NoError(t, err)
@@ -95,6 +96,76 @@ func decodeJSONSerializable(data []byte) (any, error) {
 	var m jsonSerializable
 	err := m.Deserialize(data)
 	return &m, err
+}
+
+// TestAppendToLog_KeepsEveryEntryWrittenInTheSameInstant is the regression for
+// keys built from the clock alone: appends made inside one nanosecond tick
+// produced the same key, and each silently replaced the last.
+func TestAppendToLog_KeepsEveryEntryWrittenInTheSameInstant(t *testing.T) {
+	const entries = 500
+
+	for i := range entries {
+		AppendToLog("tightloop", &jsonSerializable{Topic: "tightloop", Message: fmt.Sprintf("message%d", i)})
+	}
+	require.NoError(t, SyncLog())
+
+	gotten, err := GetLogEntriesByPrefix("tightloop", entries*2, decodeJSONSerializable)
+	require.NoError(t, err)
+	require.Len(t, gotten, entries)
+
+	for i, entry := range gotten {
+		got := entry.(*jsonSerializable)
+		assert.Equal(t, fmt.Sprintf("message%d", i), got.Message, "entry %d is out of order", i)
+	}
+}
+
+// TestAppendToLog_ConcurrentProducers verifies what several requests appending
+// to their own threads at once rely on: nothing is lost, and each thread reads
+// back in the order that thread was written.
+func TestAppendToLog_ConcurrentProducers(t *testing.T) {
+	const producers, each = 8, 50
+
+	var wg sync.WaitGroup
+	for p := range producers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			prefix := fmt.Sprintf("producer%d", p)
+			for i := range each {
+				AppendToLog(prefix, &jsonSerializable{Topic: prefix, Message: fmt.Sprintf("message%d", i)})
+			}
+		}()
+	}
+	wg.Wait()
+	require.NoError(t, SyncLog())
+
+	for p := range producers {
+		prefix := fmt.Sprintf("producer%d", p)
+		gotten, err := GetLogEntriesByPrefix(prefix, each*2, decodeJSONSerializable)
+		require.NoError(t, err)
+		require.Len(t, gotten, each, "%s lost entries", prefix)
+
+		for i, entry := range gotten {
+			got := entry.(*jsonSerializable)
+			assert.Equal(t, fmt.Sprintf("message%d", i), got.Message, "%s entry %d is out of order", prefix, i)
+		}
+	}
+}
+
+// TestSyncLog_MakesAppendsReadable is the guarantee a handler leans on when it
+// hands one turn's thread over to the next: what SyncLog has returned for, a
+// reader can see.
+func TestSyncLog_MakesAppendsReadable(t *testing.T) {
+	AppendToLog("handover", &jsonSerializable{Topic: "handover", Message: "first turn"})
+	require.NoError(t, SyncLog())
+
+	gotten, err := GetLogEntriesByPrefix("handover", 10, decodeJSONSerializable)
+	require.NoError(t, err)
+	require.Len(t, gotten, 1)
+	assert.Equal(t, "first turn", gotten[0].(*jsonSerializable).Message)
+
+	// A sync with nothing queued is a no-op, not a hang.
+	require.NoError(t, SyncLog())
 }
 
 func TestSetAndGet(t *testing.T) {
@@ -213,9 +284,9 @@ func BenchmarkWriteAndGetEntriesJSON(b *testing.B) {
 		}
 
 		for n := 0; n < b.N; n++ {
-			err := WriteToLog("benchmarkwritejson", entries)
-			require.NoError(b, err)
+			AppendToLog("benchmarkwritejson", entries...)
 		}
+		require.NoError(b, SyncLog())
 	})
 
 	var once sync.Once
@@ -227,8 +298,8 @@ func BenchmarkWriteAndGetEntriesJSON(b *testing.B) {
 				&jsonSerializable{Topic: "topic1", Message: "message2"},
 				&jsonSerializable{Topic: "topic2", Message: "message3"},
 			}
-			err := WriteToLog("benchmarkreadjson", entries)
-			require.NoError(b, err)
+			AppendToLog("benchmarkreadjson", entries...)
+			require.NoError(b, SyncLog())
 		})
 
 		for n := 0; n < b.N; n++ {
@@ -309,9 +380,9 @@ func BenchmarkWriteAndGetEntriesFLB(b *testing.B) {
 		}
 
 		for n := 0; n < b.N; n++ {
-			err := WriteToLog("benchmarkwriteflb", entries)
-			require.NoError(b, err)
+			AppendToLog("benchmarkwriteflb", entries...)
 		}
+		require.NoError(b, SyncLog())
 	})
 
 	var once sync.Once
@@ -323,8 +394,8 @@ func BenchmarkWriteAndGetEntriesFLB(b *testing.B) {
 				&flatBufferMessage{Topic: "topic1", Message: "message2"},
 				&flatBufferMessage{Topic: "topic2", Message: "message3"},
 			}
-			err := WriteToLog("benchmarkreadflb", entries)
-			require.NoError(b, err)
+			AppendToLog("benchmarkreadflb", entries...)
+			require.NoError(b, SyncLog())
 		})
 
 		for n := 0; n < b.N; n++ {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -52,11 +53,7 @@ func TestWriteAndGetEntries(t *testing.T) {
 		err := WriteToLog("conversations", entries)
 		require.NoError(t, err)
 
-		gotten, err := GetLogEntriesByPrefix("conversations", func(data []byte) (any, error) {
-			var m jsonSerializable
-			err := m.Deserialize(data)
-			return &m, err
-		})
+		gotten, err := GetLogEntriesByPrefix("conversations", 10, decodeJSONSerializable)
 		require.NoError(t, err)
 
 		expected := []any{
@@ -67,14 +64,37 @@ func TestWriteAndGetEntries(t *testing.T) {
 		assert.Equal(t, expected, gotten)
 	})
 
+	t.Run("a limit smaller than the log returns its most recent entries, oldest first", func(t *testing.T) {
+		entries := make([]Serializable, 0, 6)
+		for i := 1; i <= 6; i++ {
+			entries = append(entries, &jsonSerializable{Topic: "windowed", Message: fmt.Sprintf("message%d", i)})
+		}
+		require.NoError(t, WriteToLog("windowed", entries))
+
+		gotten, err := GetLogEntriesByPrefix("windowed", 2, decodeJSONSerializable)
+		require.NoError(t, err)
+
+		assert.Equal(t, []any{
+			&jsonSerializable{Topic: "windowed", Message: "message5"},
+			&jsonSerializable{Topic: "windowed", Message: "message6"},
+		}, gotten)
+	})
+
 	t.Run("empty prefix returns no entries", func(t *testing.T) {
-		_, err := GetLogEntriesByPrefix("", func(data []byte) (any, error) {
-			var m jsonSerializable
-			err := m.Deserialize(data)
-			return &m, err
-		})
+		_, err := GetLogEntriesByPrefix("", 10, decodeJSONSerializable)
 		require.Error(t, err)
 	})
+
+	t.Run("a non-positive limit is refused", func(t *testing.T) {
+		_, err := GetLogEntriesByPrefix("conversations", 0, decodeJSONSerializable)
+		require.Error(t, err)
+	})
+}
+
+func decodeJSONSerializable(data []byte) (any, error) {
+	var m jsonSerializable
+	err := m.Deserialize(data)
+	return &m, err
 }
 
 func TestSetAndGet(t *testing.T) {
@@ -212,7 +232,7 @@ func BenchmarkWriteAndGetEntriesJSON(b *testing.B) {
 		})
 
 		for n := 0; n < b.N; n++ {
-			gotten, err := GetLogEntriesByPrefix("benchmarkreadjson", func(data []byte) (any, error) {
+			gotten, err := GetLogEntriesByPrefix("benchmarkreadjson", 50, func(data []byte) (any, error) {
 				var m jsonSerializable
 				err := json.Unmarshal(data, &m)
 				return &m, err
@@ -308,7 +328,7 @@ func BenchmarkWriteAndGetEntriesFLB(b *testing.B) {
 		})
 
 		for n := 0; n < b.N; n++ {
-			gotten, err := GetLogEntriesByPrefix("benchmarkreadflb", func(data []byte) (any, error) {
+			gotten, err := GetLogEntriesByPrefix("benchmarkreadflb", 50, func(data []byte) (any, error) {
 				fb := flatBufferMessage{}
 				return &fb, fb.Deserialize(data)
 			})


### PR DESCRIPTION
A conversation thread was a shared object with an owner. A sub-workflow adopted
its caller's by pointer, so one of several requests holding it had to be the one
that wrote it at completion, and the request lifecycle carried the bit that said
which. The sharing bought a sub-workflow its caller's context for free, and cost
the caller a permanent record of the sub-run's internals — every tool call and
tool result, re-fed to the model on every later turn of that chat.

## What changes

**A thread belongs to one request.** A child request gets a fresh one named under
its caller's (`chat_123/sub_1`), so a sub-workflow speaks into its own record and
hands back only its result. The lineage in the id keeps that record reachable
from the chat it happened under, and the separator is deliberately not the `:`
the log store builds keys with, so loading a parent cannot pick up its children.
With no thread shared, no request has to ask whether it is the writer:
`ownsConversation` and `conversationToPersist` are gone.

**A thread writes itself.** Appends are written through to the log store by one
background writer rather than flushed at request completion, so a turn is durable
when it is spoken instead of when the request that spoke it finishes draining its
background flows — a crashed run keeps what it said, and a fast follow-up can no
longer read a thread whose previous turn has not landed. `Sync` waits for that to
be readable, which is what a chat handing one turn to the next needs.
`Flush`, the high-water mark, and the conversation's completion hook are deleted;
the request lifecycle no longer knows conversations persist at all.

**One writer fixes the keys.** They were the write time alone, so two appends in
the same nanosecond produced the same key and the second silently replaced the
first — invisible message loss, and worse under concurrent chats. The writer
assigns each entry a counter alongside the timestamp, batches whatever has queued
into one commit, and is drained before the store closes. Existing keys still sort
and scan correctly, so there is no migration.

Also included (first commit): binding a request to a sender-named thread after
its delivery is authenticated, and loading a thread as a window on its most
recent messages rather than the whole log.

## Consequences, taken deliberately

- Two requests resuming one id work from their own copies and merge in the
  append-only log. Neither sees the other's in-flight messages, and stored order
  is flush order when they overlap.
- Sub-workflow agents no longer inherit the caller's context; what they need is
  passed as tool params or author-pinned values.
- Write failures are logged rather than returned — `storage.SetLogger` wires the
  writer's logger, and a hard exit without `Close` can drop queued appends.

## Verification

Full suite green, including under `-race`. New coverage: same-nanosecond appends
lose nothing, concurrent producers keep per-thread order, `SyncLog` makes appends
readable, a sub-run keeps its own thread and leaves the caller's untouched, and
write-through resumes without duplicating loaded history.

The servflow-pro side lands separately: `callworkflow` says the callee's result
into the caller's thread (without it, a workflow whose whole job is one call
presents nothing), and Telegram waits on `Sync` where it waited on `Flush`.