### PR TITLE
Let an action say what its output holds

### DIFF
--- a/pkg/engine/actions/executables/agent/exec.go
+++ b/pkg/engine/actions/executables/agent/exec.go
@@ -207,7 +207,11 @@ func init() {
 		Name:        "AI Agent",
 		Description: "Interacts with AI models to process queries and execute tool functions",
 		Fields:      fields,
-		UseV2:       true,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputNone,
+			Description: "An agent contributes its reply to the conversation, so there is nothing for a later step to read.",
+		},
+		UseV2: true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/authenticate/authenticate.go
+++ b/pkg/engine/actions/executables/authenticate/authenticate.go
@@ -162,6 +162,10 @@ func init() {
 		Name:        "Authenticate",
 		Description: "Validates JWT tokens and authenticates users against database records",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The authenticated subject, taken from the token's sub claim.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/delete_action/delete.go
+++ b/pkg/engine/actions/executables/delete_action/delete.go
@@ -112,6 +112,10 @@ func init() {
 		Name:        "Delete Data",
 		Description: "Deletes records from database tables based on specified filters",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputNone,
+			Description: "Deleting reports success by continuing; it publishes nothing.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/download/download.go
+++ b/pkg/engine/actions/executables/download/download.go
@@ -131,6 +131,10 @@ func init() {
 		Name:        "Download File",
 		Description: "Saves a file from the request or action output to a specified path",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The path the file was written to, relative to the workspace.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/email/email.go
+++ b/pkg/engine/actions/executables/email/email.go
@@ -129,6 +129,10 @@ func init() {
 		Name:        "Send Email",
 		Description: "Sends email messages via SMTP server",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputNone,
+			Description: "Sending mail reports success by continuing; it publishes nothing.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/fetch/fetch.go
+++ b/pkg/engine/actions/executables/fetch/fetch.go
@@ -149,6 +149,10 @@ func init() {
 		Name:        "Fetch Data",
 		Description: "Retrieves data from database tables using filters and conditions",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "The rows the query matched, with the table's own column names. One row when single is set, otherwise a list.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/fetchvector/fetchvector.go
+++ b/pkg/engine/actions/executables/fetchvector/fetchvector.go
@@ -108,6 +108,10 @@ func init() {
 		Name:        "Fetch Vectors",
 		Description: "Retrieves vector embeddings from vector databases for similarity search",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "A list of the nearest stored vectors, each carrying the fields it was saved with.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/firestore/firestore.go
+++ b/pkg/engine/actions/executables/firestore/firestore.go
@@ -95,6 +95,10 @@ func init() {
 		Name:        "Firestore",
 		Description: "Stores documents in Google Cloud Firestore database",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The document that was written, as the JSON text it was sent as.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/get_key/get_key.go
+++ b/pkg/engine/actions/executables/get_key/get_key.go
@@ -90,6 +90,10 @@ func init() {
 		Name:        "Get Key",
 		Description: "Retrieves a value from persistent storage by key",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The stored value, or empty when the key is not set.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/hash/hash.go
+++ b/pkg/engine/actions/executables/hash/hash.go
@@ -86,7 +86,11 @@ func init() {
 		Name:        "Hash Value",
 		Description: "Generates cryptographic hashes using various algorithms like bcrypt",
 		Fields:      fields,
-		UseV2:       true,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The hash of the value.",
+		},
+		UseV2: true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg map[string]interface{}
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/http/http.go
+++ b/pkg/engine/actions/executables/http/http.go
@@ -231,7 +231,11 @@ func init() {
 		Name:        "HTTP Request",
 		Description: "Makes HTTP requests to external APIs and returns the response",
 		Fields:      fields,
-		UseV2:       true,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "The response body parsed as JSON, or the text of the body when it is not JSON. Setting responsePath narrows this to the value at that path.",
+		},
+		UseV2: true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/javascript/javascript.go
+++ b/pkg/engine/actions/executables/javascript/javascript.go
@@ -165,6 +165,10 @@ func init() {
 		Name:        "JavaScript",
 		Description: "Executes JavaScript code using a servflowRun function with access to request variables",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "Whatever the script's servflowRun function returns.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/jwt/jwt.go
+++ b/pkg/engine/actions/executables/jwt/jwt.go
@@ -254,6 +254,10 @@ func init() {
 		Name:        "JWT Token",
 		Description: "Creates and validates JSON Web Tokens for authentication",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The signed token when encoding, and the token's sub claim when decoding.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/mongoquery/mongoquery.go
+++ b/pkg/engine/actions/executables/mongoquery/mongoquery.go
@@ -123,6 +123,10 @@ func init() {
 		Name:        "MongoDB Query",
 		Description: "Executes queries against MongoDB collections with filtering and projection",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "A list of the matching documents, with the collection's own field names.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/parallel/parallel.go
+++ b/pkg/engine/actions/executables/parallel/parallel.go
@@ -156,6 +156,10 @@ func init() {
 		Name:        "Run In Parallel",
 		Description: "Runs a series of specified steps and their respective next steps in parallel. If it is set to stop on failure, the step fails after the first failure",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputNone,
+			Description: "Read the outputs of the steps it ran, not of this step.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/save/save.go
+++ b/pkg/engine/actions/executables/save/save.go
@@ -213,7 +213,13 @@ func init() {
 		Name:        "Save Data",
 		Description: "Inserts new records or updates existing records in database tables. When filters are provided, updates matching records; otherwise inserts a new record.",
 		Fields:      fields,
-		UseV2:       true,
+		Output: actions.OutputInfo{
+			Kind: actions.OutputObject,
+			Fields: []actions.OutputField{
+				{Path: "id", Type: "string", Description: "The id of the saved record."},
+			},
+		},
+		UseV2: true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/static/static.go
+++ b/pkg/engine/actions/executables/static/static.go
@@ -72,7 +72,11 @@ func init() {
 		Name:        "Static Value",
 		Description: "Returns a static value configured at setup time",
 		Fields:      fields,
-		UseV2:       true,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The text of the return template, with its variables filled in.",
+		},
+		UseV2: true,
 		ConstructorV2: func(config json.RawMessage) (actions.ActionExecutableV2, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/store_key/store_key.go
+++ b/pkg/engine/actions/executables/store_key/store_key.go
@@ -81,6 +81,10 @@ func init() {
 		Name:        "Store Key",
 		Description: "Stores a key-value pair in persistent storage",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputValue,
+			Description: "The value that was stored.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/storevector/storevector.go
+++ b/pkg/engine/actions/executables/storevector/storevector.go
@@ -115,6 +115,10 @@ func init() {
 		Name:        "Store Vectors",
 		Description: "Stores vector embeddings into vector databases for similarity search",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputNone,
+			Description: "Storing vectors reports success by continuing; it publishes nothing.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/stub/stub.go
+++ b/pkg/engine/actions/executables/stub/stub.go
@@ -46,6 +46,10 @@ func init() {
 		Name:        "Stub Action",
 		Description: "A placeholder action that accepts any configuration for testing purposes",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputDynamic,
+			Description: "The configured response, echoed back as it was written.",
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var fields map[string]interface{}
 			if err := json.Unmarshal(config, &fields); err != nil {

--- a/pkg/engine/actions/executables/update/update.go
+++ b/pkg/engine/actions/executables/update/update.go
@@ -118,6 +118,12 @@ func init() {
 		Name:        "Update Data",
 		Description: "Updates existing records in database tables using filters and field mappings",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind: actions.OutputObject,
+			Fields: []actions.OutputField{
+				{Path: "id", Type: "string", Description: "The id of the updated record."},
+			},
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/executables/write/write.go
+++ b/pkg/engine/actions/executables/write/write.go
@@ -121,6 +121,13 @@ func init() {
 		Name:        "Write Data",
 		Description: "Stores data records into database tables with field mapping",
 		Fields:      fields,
+		Output: actions.OutputInfo{
+			Kind:        actions.OutputObject,
+			Description: "The record that was written, holding the fields it was given.",
+			Fields: []actions.OutputField{
+				{Path: "id", Type: "string", Description: "The record's id, generated when the fields did not carry one."},
+			},
+		},
 		Constructor: func(config json.RawMessage) (actions.ActionExecutable, error) {
 			var cfg Config
 			if err := json.Unmarshal(config, &cfg); err != nil {

--- a/pkg/engine/actions/output.go
+++ b/pkg/engine/actions/output.go
@@ -1,0 +1,135 @@
+package actions
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// An action's result is stored as a request variable under the action's own id,
+// so a later step reads it as "{{ .stepID }}" or, when the result is a map,
+// "{{ .stepID.some.path }}". Nothing in the registry used to say which of those
+// two an action produced, or what paths were inside it, so the dashboard could
+// only ever offer the bare id. The types here are that missing description.
+
+// OutputKind says how much of an action's output is known before it runs.
+type OutputKind string
+
+const (
+	// OutputDynamic is a shape that depends on data the action has not seen
+	// yet — a remote API's response, a stored value, another workflow's reply.
+	// The output is offered whole and the caller picks paths out of it. This is
+	// the zero value, so an action nobody has described yet keeps working.
+	OutputDynamic OutputKind = ""
+	// OutputNone is an action that publishes no request variable at all.
+	OutputNone OutputKind = "none"
+	// OutputValue is a single value with nothing to address inside it, read as
+	// "{{ .stepID }}".
+	OutputValue OutputKind = "value"
+	// OutputObject is a map whose keys are known, each listed in Fields and read
+	// as "{{ .stepID.<path> }}".
+	OutputObject OutputKind = "object"
+)
+
+// OutputField is one addressable path inside an action's output.
+type OutputField struct {
+	// Path is what follows the step id, dotted for nesting: "meta.title" is read
+	// as "{{ .stepID.meta.title }}".
+	Path        string `json:"path"`
+	Type        string `json:"type"` // string, number, boolean, object, array, or any
+	Description string `json:"description"`
+}
+
+// OutputInfo describes an action's output.
+//
+// An action whose shape is chosen by one of its own config fields — a resource
+// selector, a mode — sets VariantField to that field's name and lists a shape
+// per value in Variants. Variants are plain OutputInfo but only one level deep:
+// a variant's own VariantField is never consulted.
+type OutputInfo struct {
+	Kind OutputKind `json:"kind"`
+	// Description says in one line what the output holds. It is the only
+	// guidance a dynamic output can offer, so it is worth naming the paths a
+	// caller is likely to want.
+	Description  string                `json:"description,omitempty"`
+	Fields       []OutputField         `json:"fields,omitempty"`
+	VariantField string                `json:"variantField,omitempty"`
+	Variants     map[string]OutputInfo `json:"variants,omitempty"`
+}
+
+// MarshalJSON writes the kind out in full.
+//
+// OutputDynamic is the empty string so that an undescribed action is dynamic
+// without anyone writing it down, but a reader of the generated catalog should
+// not have to know that. On the wire the kind is always one of the four names.
+func (o OutputInfo) MarshalJSON() ([]byte, error) {
+	type wire OutputInfo
+	out := wire(o)
+	if out.Kind == OutputDynamic {
+		out.Kind = "dynamic"
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON accepts the name MarshalJSON writes as well as the empty
+// string, so a value survives a round trip through JSON unchanged.
+func (o *OutputInfo) UnmarshalJSON(data []byte) error {
+	type wire OutputInfo
+	var in wire
+	if err := json.Unmarshal(data, &in); err != nil {
+		return err
+	}
+	if in.Kind == "dynamic" {
+		in.Kind = OutputDynamic
+	}
+	*o = OutputInfo(in)
+	return nil
+}
+
+// For resolves the output shape of one configured instance of an action, where
+// config holds that instance's config field values.
+//
+// A variant output falls back to the base shape while its selector is unset or
+// holds a value no variant claims, which is what a half-filled form in the
+// dashboard looks like.
+func (o OutputInfo) For(config map[string]string) OutputInfo {
+	if o.VariantField == "" {
+		return o
+	}
+	variant, ok := o.Variants[config[o.VariantField]]
+	if !ok {
+		return o
+	}
+	return variant
+}
+
+// validate rejects a description that cannot be resolved against the action's
+// own config fields. Registration is the only moment this can be caught: once
+// the dashboard is reading a selector that names no field, all it can do is
+// offer the wrong variables and let them resolve to empty at run time.
+func (o OutputInfo) validate(fields map[string]FieldInfo) error {
+	if o.VariantField == "" {
+		if len(o.Variants) > 0 {
+			return errors.New("output declares variants without a variantField")
+		}
+		return nil
+	}
+	field, ok := fields[o.VariantField]
+	if !ok {
+		return fmt.Errorf("output variantField %q is not a config field", o.VariantField)
+	}
+	if len(o.Variants) == 0 {
+		return fmt.Errorf("output variantField %q has no variants", o.VariantField)
+	}
+	// When the selector has a closed set of values, every variant must name one
+	// of them. A variant keyed on a value the field cannot hold is unreachable.
+	if len(field.Values) > 0 {
+		for value := range o.Variants {
+			if !slices.Contains(field.Values, value) {
+				return fmt.Errorf("output variant %q is not a value of field %q", value, o.VariantField)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/engine/actions/output_test.go
+++ b/pkg/engine/actions/output_test.go
@@ -1,0 +1,228 @@
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputInfoFor(t *testing.T) {
+	base := OutputInfo{
+		Kind:         OutputDynamic,
+		Description:  "whatever the resource returns",
+		VariantField: "resource",
+		Variants: map[string]OutputInfo{
+			"diff": {Kind: OutputValue, Description: "the diff text"},
+			"meta": {
+				Kind:   OutputObject,
+				Fields: []OutputField{{Path: "title", Type: "string"}},
+			},
+		},
+	}
+
+	t.Run("selected variant wins", func(t *testing.T) {
+		got := base.For(map[string]string{"resource": "meta"})
+		assert.Equal(t, OutputObject, got.Kind)
+		require.Len(t, got.Fields, 1)
+		assert.Equal(t, "title", got.Fields[0].Path)
+	})
+
+	t.Run("unset selector falls back to the base shape", func(t *testing.T) {
+		got := base.For(map[string]string{})
+		assert.Equal(t, OutputDynamic, got.Kind)
+		assert.Equal(t, "whatever the resource returns", got.Description)
+	})
+
+	t.Run("unknown selector value falls back to the base shape", func(t *testing.T) {
+		got := base.For(map[string]string{"resource": "{{ .step.resource }}"})
+		assert.Equal(t, OutputDynamic, got.Kind)
+	})
+
+	t.Run("output without variants resolves to itself", func(t *testing.T) {
+		plain := OutputInfo{Kind: OutputValue, Description: "command output"}
+		assert.Equal(t, plain, plain.For(map[string]string{"resource": "meta"}))
+	})
+
+	t.Run("a variant's own variants are not followed", func(t *testing.T) {
+		nested := OutputInfo{
+			VariantField: "mode",
+			Variants: map[string]OutputInfo{
+				"one": {
+					Kind:         OutputValue,
+					VariantField: "inner",
+					Variants:     map[string]OutputInfo{"deep": {Kind: OutputObject}},
+				},
+			},
+		}
+		got := nested.For(map[string]string{"mode": "one", "inner": "deep"})
+		assert.Equal(t, OutputValue, got.Kind)
+	})
+}
+
+func TestOutputInfoJSON(t *testing.T) {
+	t.Run("dynamic is written out by name", func(t *testing.T) {
+		data, err := json.Marshal(OutputInfo{Kind: OutputDynamic, Description: "a remote reply"})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"kind":"dynamic"`)
+	})
+
+	t.Run("nested variants are written out by name", func(t *testing.T) {
+		data, err := json.Marshal(OutputInfo{
+			VariantField: "resource",
+			Variants:     map[string]OutputInfo{"meta": {Kind: OutputDynamic}},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"meta":{"kind":"dynamic"}`)
+	})
+
+	t.Run("a round trip through JSON keeps the value", func(t *testing.T) {
+		original := OutputInfo{
+			Kind:         OutputDynamic,
+			VariantField: "resource",
+			Variants: map[string]OutputInfo{
+				"diff": {Kind: OutputValue, Description: "diff text"},
+				"meta": {Kind: OutputObject, Fields: []OutputField{{Path: "title", Type: "string"}}},
+			},
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var round OutputInfo
+		require.NoError(t, json.Unmarshal(data, &round))
+		assert.Equal(t, original, round)
+	})
+
+	t.Run("the other kinds are unchanged", func(t *testing.T) {
+		for _, kind := range []OutputKind{OutputNone, OutputValue, OutputObject} {
+			data, err := json.Marshal(OutputInfo{Kind: kind})
+			require.NoError(t, err)
+			assert.Contains(t, string(data), fmt.Sprintf(`"kind":%q`, kind))
+		}
+	})
+}
+
+func TestRegisterActionValidatesOutput(t *testing.T) {
+	constructor := func(config json.RawMessage) (ActionExecutable, error) {
+		return &mockActionExecutable{}, nil
+	}
+	resourceField := map[string]FieldInfo{
+		"resource": {Type: FieldTypeString, Values: []string{"diff", "meta"}},
+	}
+
+	t.Run("variantField naming no config field is rejected", func(t *testing.T) {
+		err := RegisterAction("output-unknown-selector", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      resourceField,
+			Output: OutputInfo{
+				VariantField: "kind",
+				Variants:     map[string]OutputInfo{"diff": {Kind: OutputValue}},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `variantField "kind" is not a config field`)
+		assert.False(t, HasRegisteredActionType("output-unknown-selector"))
+	})
+
+	t.Run("variant outside the field's values is rejected", func(t *testing.T) {
+		err := RegisterAction("output-unknown-variant", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      resourceField,
+			Output: OutputInfo{
+				VariantField: "resource",
+				Variants:     map[string]OutputInfo{"patch": {Kind: OutputValue}},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `variant "patch" is not a value of field "resource"`)
+	})
+
+	t.Run("variantField without variants is rejected", func(t *testing.T) {
+		err := RegisterAction("output-empty-variants", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      resourceField,
+			Output:      OutputInfo{VariantField: "resource"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no variants")
+	})
+
+	t.Run("variants without a variantField are rejected", func(t *testing.T) {
+		err := RegisterAction("output-orphan-variants", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      resourceField,
+			Output:      OutputInfo{Variants: map[string]OutputInfo{"diff": {Kind: OutputValue}}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "variants without a variantField")
+	})
+
+	t.Run("a valid variant declaration registers", func(t *testing.T) {
+		err := RegisterAction("output-valid-variants", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      resourceField,
+			Output: OutputInfo{
+				VariantField: "resource",
+				Variants: map[string]OutputInfo{
+					"diff": {Kind: OutputValue},
+					"meta": {Kind: OutputObject, Fields: []OutputField{{Path: "title", Type: "string"}}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		info, err := GetInfoForAction("output-valid-variants")
+		require.NoError(t, err)
+		assert.Equal(t, "resource", info.Output.VariantField)
+	})
+
+	t.Run("an undescribed action registers as dynamic", func(t *testing.T) {
+		err := RegisterAction("output-undescribed", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      map[string]FieldInfo{},
+		})
+		require.NoError(t, err)
+
+		info, err := GetInfoForAction("output-undescribed")
+		require.NoError(t, err)
+		assert.Equal(t, OutputDynamic, info.Output.Kind)
+	})
+
+	t.Run("a selector field with open values accepts any variant", func(t *testing.T) {
+		err := RegisterAction("output-open-selector", ActionRegistrationInfo{
+			Constructor: constructor,
+			Fields:      map[string]FieldInfo{"mode": {Type: FieldTypeString}},
+			Output: OutputInfo{
+				VariantField: "mode",
+				Variants:     map[string]OutputInfo{"anything": {Kind: OutputValue}},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestReplaceActionTypeKeepsOutput(t *testing.T) {
+	err := RegisterAction("output-replaceable", ActionRegistrationInfo{
+		Constructor: func(config json.RawMessage) (ActionExecutable, error) {
+			return &mockActionExecutable{config: "original"}, nil
+		},
+		Fields: map[string]FieldInfo{},
+		Output: OutputInfo{
+			Kind:   OutputObject,
+			Fields: []OutputField{{Path: "title", Type: "string"}},
+		},
+	})
+	require.NoError(t, err)
+
+	ReplaceActionType("output-replaceable", func(config json.RawMessage) (ActionExecutable, error) {
+		return &mockActionExecutable{config: "replaced"}, nil
+	})
+
+	info, err := GetInfoForAction("output-replaceable")
+	require.NoError(t, err)
+	assert.Equal(t, OutputObject, info.Output.Kind)
+	require.Len(t, info.Output.Fields, 1)
+	assert.Equal(t, "title", info.Output.Fields[0].Path)
+}

--- a/pkg/engine/actions/registry.go
+++ b/pkg/engine/actions/registry.go
@@ -13,12 +13,17 @@ type Registry struct {
 }
 
 type ActionRegistrationInfo struct {
-	Name          string               `json:"name"`
-	Description   string               `json:"description"`
-	Fields        map[string]FieldInfo `json:"fields"`
-	Constructor   factoryFunc          `json:"-"`
-	ConstructorV2 factoryFuncV2        `json:"-"` // V2 constructor (used when UseV2 is true)
-	UseV2         bool                 `json:"-"` // If true, use V2 interface (action handles own template resolution)
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Fields      map[string]FieldInfo `json:"fields"`
+	// Output describes what the action publishes as a request variable, so the
+	// dashboard can offer the paths a later step may read. The zero value means
+	// OutputDynamic: an action that has not been described yet keeps working and
+	// is offered whole.
+	Output        OutputInfo    `json:"output"`
+	Constructor   factoryFunc   `json:"-"`
+	ConstructorV2 factoryFuncV2 `json:"-"` // V2 constructor (used when UseV2 is true)
+	UseV2         bool          `json:"-"` // If true, use V2 interface (action handles own template resolution)
 }
 
 type FieldType string
@@ -68,6 +73,9 @@ func (r *Registry) RegisterAction(actionType string, registration ActionRegistra
 	if ok {
 		return fmt.Errorf("action type %s already registered", actionType)
 	}
+	if err := registration.Output.validate(registration.Fields); err != nil {
+		return fmt.Errorf("action type %s: %w", actionType, err)
+	}
 	r.availableConstructors[actionType] = registration
 	return nil
 }
@@ -97,6 +105,7 @@ func (r *Registry) ReplaceActionType(actionType string, constructor factoryFunc)
 		Name:        existing.Name,
 		Description: existing.Description,
 		Fields:      existing.Fields,
+		Output:      existing.Output,
 	}
 }
 


### PR DESCRIPTION
## Why

An action's result is stored as a request variable under the action's own id, so a later step reads it as `{{ .stepID }}` or `{{ .stepID.some.path }}`. Nothing in the registry said which of those two an action produced, or what paths were inside it.

The dashboard could therefore only ever offer a step as a bare id. Writing a prompt against a step meant reading the action's Go source to learn its paths, and actions that publish nothing at all — `parallel`, `email`, `storevector` — were still offered as variables that always resolved to empty.

## What

`ActionRegistrationInfo` gains an `Output`, defined in the new `pkg/engine/actions/output.go`:

- **`kind`** is one of `none` (publishes no variable), `value` (nothing to address inside it), `object` (a list of addressable paths), or `dynamic` (shape depends on data the action has not seen yet).
- **`fields`** lists the paths of an object, dotted for nesting.
- **`variantField`/`variants`** describe an action whose shape is chosen by one of its own config fields — a resource selector, a mode. `OutputInfo.For(config)` resolves one against a configured step, falling back to the base shape while the selector is unset.

`OutputDynamic` is the empty string, so an action nobody has described keeps behaving exactly as it did. `MarshalJSON` writes the kind out in full regardless, so a reader of the generated catalog never has to know that.

`RegisterAction` rejects a description that cannot be resolved against the action's own config fields: a selector naming no field, a selector with no variants, variants with no selector, or a variant keyed on a value a closed field cannot hold. Registration is the only moment this is catchable — afterwards the dashboard can only offer the wrong variables and let them come back empty at run time.

All 22 executables are described.

## Tests

17 new tests in `pkg/engine/actions/output_test.go`:

- `TestOutputInfoFor` — variant resolution, including the fallbacks for an unset selector and for one written as a template, and that a variant's own variants are not followed.
- `TestOutputInfoJSON` — the zero kind marshals as `"dynamic"` rather than `""`, nested variants get the same treatment, and a value survives a round trip.
- `TestRegisterActionValidatesOutput` — each rejection above, plus that a correct declaration registers and an undescribed action registers as dynamic.
- `TestReplaceActionTypeKeepsOutput` — replacing a constructor preserves the declaration, alongside name/description/fields.

`go build ./...` and `go test ./...` are clean.

## Downstream

This is what pro's generated action catalog carries into the agent studio's insert-variable menu, so a step offers the paths inside its output instead of an opaque id. That side is a separate change and depends on this being published.