### PR TITLE
Let one action run without a plan around it

### DIFF
--- a/pkg/engine/actions/runner.go
+++ b/pkg/engine/actions/runner.go
@@ -1,0 +1,78 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
+)
+
+// Runner is one registered action, runnable on its own.
+//
+// It owns what a caller would otherwise repeat by hand: constructing the
+// executable from the registry, resolving its config against the request, and
+// knowing which of the two action generations it is holding. A plan step is
+// the usual way to run an action, but not the only one — an agent tool runs a
+// single action per call, with no graph around it — and that caller should not
+// have to know that v1 receives a rendered config string while v2 resolves its
+// own.
+//
+// The lifecycle matches the planner's: construct once, resolve per execution.
+type Runner struct {
+	actionType string
+	v1         ActionExecutable
+	v2         ActionExecutableV2
+}
+
+// NewRunner constructs the executable for the action type's generation.
+//
+// It fails on an unregistered type, so holding a *Runner means the action
+// exists and its config unmarshalled. Building at construction rather than at
+// execution is what lets a caller reject a bad config while it is being set
+// up, instead of at the first call.
+func NewRunner(actionType string, config json.RawMessage) (*Runner, error) {
+	if IsV2Action(actionType) {
+		exec, err := GetActionExecutableV2(actionType, config)
+		if err != nil {
+			return nil, fmt.Errorf("action %q: %w", actionType, err)
+		}
+		return &Runner{actionType: actionType, v2: exec}, nil
+	}
+
+	exec, err := GetActionExecutable(actionType, config)
+	if err != nil {
+		return nil, fmt.Errorf("action %q: %w", actionType, err)
+	}
+	return &Runner{actionType: actionType, v1: exec}, nil
+}
+
+// Type is the action type this runner executes.
+func (r *Runner) Type() string {
+	return r.actionType
+}
+
+// Execute resolves the action's config and runs it, returning what the action
+// returned along with its trace fields.
+//
+// A v2 action resolves its own config, so ctx is handed to it untouched — any
+// overlay on ctx (requestctx.WithTemplateFuncs) is in scope for that
+// resolution. A v1 action does not resolve anything: its config template is
+// rendered here and passed in, the same contract the plan executor honours.
+//
+// The result is returned as the action produced it. Scrubbing belongs to
+// whoever externalizes it, which is where the plan step does it too.
+func (r *Runner) Execute(ctx context.Context) (resp interface{}, fields map[string]string, err error) {
+	if r.v2 != nil {
+		return r.v2.Execute(ctx)
+	}
+
+	var resolved string
+	if config := r.v1.Config(); config != "" {
+		resolved, err = requestctx.ExecuteTemplateString(ctx, config)
+		if err != nil {
+			return nil, nil, fmt.Errorf("action %q: resolving config: %w", r.actionType, err)
+		}
+	}
+	return r.v1.Execute(ctx, resolved)
+}

--- a/pkg/engine/actions/runner_test.go
+++ b/pkg/engine/actions/runner_test.go
@@ -1,0 +1,237 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"text/template"
+
+	"github.com/Servflow/servflow/pkg/engine/requestctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runnerV1 records the config it was handed so a test can assert on what the
+// runner resolved before calling it.
+type runnerV1 struct {
+	config     string
+	gotConfig  string
+	response   interface{}
+	fields     map[string]string
+	executeErr error
+}
+
+func (m *runnerV1) Type() string   { return "runner-v1" }
+func (m *runnerV1) Config() string { return m.config }
+func (m *runnerV1) Execute(_ context.Context, modifiedConfig string) (interface{}, map[string]string, error) {
+	m.gotConfig = modifiedConfig
+	return m.response, m.fields, m.executeErr
+}
+
+// runnerV2 resolves its own config, as a real v2 action does.
+type runnerV2 struct {
+	config     string
+	resolved   string
+	response   interface{}
+	fields     map[string]string
+	executeErr error
+}
+
+func (m *runnerV2) Type() string { return "runner-v2" }
+func (m *runnerV2) Execute(ctx context.Context) (interface{}, map[string]string, error) {
+	if m.executeErr != nil {
+		return nil, nil, m.executeErr
+	}
+	rc, err := requestctx.FromContextOrError(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	m.resolved, err = rc.Resolve(ctx, m.config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return m.response, m.fields, nil
+}
+
+// registerRunnerV1 and registerRunnerV2 register an action type for one test
+// and return its name. Registration is global and permanent, so every name is
+// unique, and the executable is fixed by the test rather than built from the
+// config.
+func registerRunnerV1(t *testing.T, name string, exec *runnerV1) string {
+	t.Helper()
+	require.NoError(t, RegisterAction(name, ActionRegistrationInfo{
+		Constructor: func(json.RawMessage) (ActionExecutable, error) {
+			return exec, nil
+		},
+		Fields: map[string]FieldInfo{},
+	}))
+	return name
+}
+
+func registerRunnerV2(t *testing.T, name string, exec *runnerV2) string {
+	t.Helper()
+	require.NoError(t, RegisterAction(name, ActionRegistrationInfo{
+		UseV2: true,
+		ConstructorV2: func(json.RawMessage) (ActionExecutableV2, error) {
+			return exec, nil
+		},
+		Fields: map[string]FieldInfo{},
+	}))
+	return name
+}
+
+func TestNewRunner_UnregisteredType(t *testing.T) {
+	_, err := NewRunner("runner-no-such-action", json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runner-no-such-action")
+}
+
+func TestNewRunner_ConstructorError(t *testing.T) {
+	name := "runner-bad-constructor"
+	require.NoError(t, RegisterAction(name, ActionRegistrationInfo{
+		Constructor: func(json.RawMessage) (ActionExecutable, error) {
+			return nil, errors.New("bad config")
+		},
+		Fields: map[string]FieldInfo{},
+	}))
+
+	// A config the action rejects fails while the runner is built, not at the
+	// first call.
+	_, err := NewRunner(name, json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad config")
+}
+
+func TestRunner_V1ReceivesResolvedConfig(t *testing.T) {
+	exec := &runnerV1{
+		config:   `{"symbol":"{{ .stored }}"}`,
+		response: "ok",
+	}
+	name := registerRunnerV1(t, "runner-v1-resolves", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{"symbol":"{{ .stored }}"}`))
+	require.NoError(t, err)
+	assert.Equal(t, name, runner.Type())
+
+	ctx := requestctx.NewTestContext()
+	require.NoError(t, requestctx.AddRequestVariables(ctx, map[string]interface{}{
+		"stored": "BTCUSDT",
+	}, ""))
+
+	resp, _, err := runner.Execute(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+	assert.Equal(t, `{"symbol":"BTCUSDT"}`, exec.gotConfig,
+		"v1 gets its config template rendered, as the plan executor does it")
+}
+
+func TestRunner_V1SeesContextOverlay(t *testing.T) {
+	exec := &runnerV1{config: `{"symbol":"{{ tool_param \"symbol\" }}"}`}
+	name := registerRunnerV1(t, "runner-v1-overlay", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	ctx := requestctx.WithTemplateFuncs(requestctx.NewTestContext(), template.FuncMap{
+		"tool_param": func(string) string { return "ETHUSDT" },
+	})
+
+	_, _, err = runner.Execute(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, `{"symbol":"ETHUSDT"}`, exec.gotConfig)
+}
+
+func TestRunner_V1EmptyConfigIsNotResolved(t *testing.T) {
+	exec := &runnerV1{config: ""}
+	name := registerRunnerV1(t, "runner-v1-empty", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	_, _, err = runner.Execute(requestctx.NewTestContext())
+	require.NoError(t, err)
+	assert.Empty(t, exec.gotConfig)
+}
+
+func TestRunner_V1ResolutionErrorIsReported(t *testing.T) {
+	exec := &runnerV1{config: `{{ notAFunction }}`}
+	name := registerRunnerV1(t, "runner-v1-bad-template", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	_, _, err = runner.Execute(requestctx.NewTestContext())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving config")
+	assert.Empty(t, exec.gotConfig, "a config that fails to resolve never reaches the action")
+}
+
+func TestRunner_V2ResolvesItsOwnConfig(t *testing.T) {
+	exec := &runnerV2{
+		config:   `{{ .stored }}`,
+		response: map[string]any{"balance": 10},
+	}
+	name := registerRunnerV2(t, "runner-v2-resolves", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	ctx := requestctx.NewTestContext()
+	require.NoError(t, requestctx.AddRequestVariables(ctx, map[string]interface{}{
+		"stored": "from-variables",
+	}, ""))
+
+	resp, _, err := runner.Execute(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"balance": 10}, resp)
+	assert.Equal(t, "from-variables", exec.resolved)
+}
+
+func TestRunner_V2SeesContextOverlay(t *testing.T) {
+	exec := &runnerV2{config: `{{ tool_param "symbol" }}`}
+	name := registerRunnerV2(t, "runner-v2-overlay", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	// The v2 action resolves for itself, so the overlay has to survive being
+	// passed through the runner untouched.
+	ctx := requestctx.WithTemplateFuncs(requestctx.NewTestContext(), template.FuncMap{
+		"tool_param": func(key string) string { return "arg-" + key },
+	})
+
+	_, _, err = runner.Execute(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "arg-symbol", exec.resolved)
+}
+
+func TestRunner_ExecutionErrorPassesThrough(t *testing.T) {
+	sentinel := errors.New("action failed")
+
+	v1 := &runnerV1{config: `{}`, executeErr: sentinel}
+	v1Name := registerRunnerV1(t, "runner-v1-error", v1)
+	v1Runner, err := NewRunner(v1Name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	_, _, err = v1Runner.Execute(requestctx.NewTestContext())
+	assert.ErrorIs(t, err, sentinel)
+
+	v2 := &runnerV2{config: `{}`, executeErr: sentinel}
+	v2Name := registerRunnerV2(t, "runner-v2-error", v2)
+	v2Runner, err := NewRunner(v2Name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	_, _, err = v2Runner.Execute(requestctx.NewTestContext())
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestRunner_ReturnsTraceFields(t *testing.T) {
+	exec := &runnerV1{config: `{}`, fields: map[string]string{"url": "https://example.com"}}
+	name := registerRunnerV1(t, "runner-v1-fields", exec)
+
+	runner, err := NewRunner(name, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	_, fields, err := runner.Execute(requestctx.NewTestContext())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"url": "https://example.com"}, fields)
+}

--- a/pkg/engine/requestctx/dpl.go
+++ b/pkg/engine/requestctx/dpl.go
@@ -99,7 +99,7 @@ func CreateTextTemplate(reqCtx context.Context, config string, funcMap template.
 		funcMap[k] = v
 	}
 	// Use RequestContext's createTemplate which includes all functions (base + request-scoped)
-	return rCtx.createTemplate(config, funcMap)
+	return rCtx.createTemplate(reqCtx, config, funcMap)
 }
 
 func ExecuteTemplateFromContext(ctx context.Context, tmpl *template.Template) (string, error) {

--- a/pkg/engine/requestctx/templatefuncs.go
+++ b/pkg/engine/requestctx/templatefuncs.go
@@ -1,0 +1,46 @@
+package requestctx
+
+import (
+	"context"
+	"text/template"
+)
+
+// templateFuncsKey carries a template function overlay on a context.
+type templateFuncsKey struct{}
+
+// WithTemplateFuncs returns a context whose template resolutions see funcs on
+// top of the base and request-scoped functions.
+//
+// The overlay belongs to the context, not to the request: two callers holding
+// the same RequestContext but different contexts resolve independently. That
+// is what a per-call function needs — a tool argument reader is only correct
+// for the one call it was created for, so registering it on the shared
+// RequestContext (AddRequestTemplateFunctions) would let concurrent calls
+// overwrite each other.
+//
+// Overlays compose: applying this to a context that already carries one keeps
+// the outer functions and lets the inner ones win a name collision. An
+// explicit funcMap passed to CreateTextTemplate still beats both.
+func WithTemplateFuncs(ctx context.Context, funcs template.FuncMap) context.Context {
+	if len(funcs) == 0 {
+		return ctx
+	}
+	existing := templateFuncsFromContext(ctx)
+	merged := make(template.FuncMap, len(existing)+len(funcs))
+	for name, fn := range existing {
+		merged[name] = fn
+	}
+	for name, fn := range funcs {
+		merged[name] = fn
+	}
+	return context.WithValue(ctx, templateFuncsKey{}, merged)
+}
+
+// templateFuncsFromContext returns the overlay ctx carries, or nil.
+func templateFuncsFromContext(ctx context.Context) template.FuncMap {
+	if ctx == nil {
+		return nil
+	}
+	funcs, _ := ctx.Value(templateFuncsKey{}).(template.FuncMap)
+	return funcs
+}

--- a/pkg/engine/requestctx/templatefuncs_test.go
+++ b/pkg/engine/requestctx/templatefuncs_test.go
@@ -1,0 +1,172 @@
+package requestctx
+
+import (
+	"sync"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTemplateFuncs_ResolveSeesOverlay(t *testing.T) {
+	ctx := NewTestContext()
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"tool_param": func(key string) string { return "value-of-" + key },
+	})
+
+	result, err := rc.Resolve(ctx, `{{ tool_param "symbol" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "value-of-symbol", result)
+}
+
+func TestWithTemplateFuncs_ResolveBatchSeesOverlay(t *testing.T) {
+	ctx := NewTestContext()
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"tool_param": func(key string) string { return "arg:" + key },
+	})
+
+	// More than one template takes the concatenating batch path rather than
+	// delegating to Resolve, so it needs its own coverage.
+	results, err := rc.ResolveBatch(ctx, `{{ tool_param "a" }}`, `{{ tool_param "b" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"arg:a", "arg:b"}, results)
+}
+
+func TestWithTemplateFuncs_CreateTextTemplateSeesOverlay(t *testing.T) {
+	ctx := NewTestContext()
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"tool_param": func(key string) string { return "arg:" + key },
+	})
+
+	// The v1 action config path: CreateTextTemplate, then execute.
+	out, err := ExecuteTemplateString(ctx, `{{ tool_param "symbol" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "arg:symbol", out)
+}
+
+func TestWithTemplateFuncs_ResolvesAlongsideRequestFunctionsAndVariables(t *testing.T) {
+	ctx := NewTestContext()
+	require.NoError(t, AddRequestVariables(ctx, map[string]interface{}{
+		"stored": "from-variables",
+	}, ""))
+
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+	rc.AddRequestTemplateFunctions(template.FuncMap{
+		"header": func(string) string { return "from-request-func" },
+	}, false)
+
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"tool_param": func(string) string { return "from-overlay" },
+	})
+
+	// An overlay must add to what the request already offers, never replace it.
+	result, err := rc.Resolve(ctx,
+		`{{ tool_param "x" }}|{{ header "y" }}|{{ .stored }}|{{ tostring "base" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "from-overlay|from-request-func|from-variables|base", result)
+}
+
+func TestWithTemplateFuncs_ExplicitFuncMapWinsOverOverlay(t *testing.T) {
+	ctx := NewTestContext()
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"pick": func() string { return "overlay" },
+	})
+
+	tmpl, err := CreateTextTemplate(ctx, `{{ pick }}`, template.FuncMap{
+		"pick": func() string { return "caller" },
+	})
+	require.NoError(t, err)
+
+	out, err := ExecuteTemplateFromContext(ctx, tmpl)
+	require.NoError(t, err)
+	assert.Equal(t, "caller", out)
+}
+
+func TestWithTemplateFuncs_OverlaysCompose(t *testing.T) {
+	ctx := NewTestContext()
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"outer": func() string { return "outer" },
+		"both":  func() string { return "from-outer" },
+	})
+	ctx = WithTemplateFuncs(ctx, template.FuncMap{
+		"inner": func() string { return "inner" },
+		"both":  func() string { return "from-inner" },
+	})
+
+	result, err := rc.Resolve(ctx, `{{ outer }}|{{ inner }}|{{ both }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "outer|inner|from-inner", result)
+}
+
+func TestWithTemplateFuncs_NoOverlayUnchanged(t *testing.T) {
+	ctx := NewTestContext()
+	require.NoError(t, AddRequestVariables(ctx, map[string]interface{}{
+		"stored": "value",
+	}, ""))
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+
+	result, err := rc.Resolve(ctx, `{{ .stored }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "value", result)
+
+	// An empty overlay must not allocate a new context either.
+	assert.Equal(t, ctx, WithTemplateFuncs(ctx, nil))
+}
+
+func TestWithTemplateFuncs_UnknownFunctionStillFails(t *testing.T) {
+	ctx := NewTestContext()
+	rc, ok := FromContext(ctx)
+	require.True(t, ok)
+
+	// The overlay is scoped to the context that carries it: a sibling context
+	// must not see it.
+	_ = WithTemplateFuncs(ctx, template.FuncMap{"tool_param": func(string) string { return "x" }})
+
+	_, err := rc.Resolve(ctx, `{{ tool_param "a" }}`)
+	require.Error(t, err)
+}
+
+func TestWithTemplateFuncs_ConcurrentCallsAreIndependent(t *testing.T) {
+	// The reason the overlay lives on the context: two calls sharing one
+	// RequestContext must each see their own arguments. Registering per-call
+	// functions on the RequestContext itself cannot do this.
+	base := NewTestContext()
+	rc, ok := FromContext(base)
+	require.True(t, ok)
+
+	var wg sync.WaitGroup
+	results := make([]string, 50)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			want := string(rune('a' + i%26))
+			ctx := WithTemplateFuncs(base, template.FuncMap{
+				"tool_param": func(string) string { return want },
+			})
+			out, err := rc.Resolve(ctx, `{{ tool_param "k" }}`)
+			if err != nil {
+				results[i] = "error: " + err.Error()
+				return
+			}
+			results[i] = out
+		}(i)
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		assert.Equal(t, string(rune('a'+i%26)), got, "call %d saw another call's argument", i)
+	}
+}

--- a/pkg/engine/requestctx/templates.go
+++ b/pkg/engine/requestctx/templates.go
@@ -21,7 +21,7 @@ const batchSeparator = "\x00\x1F\x00" // Null + Unit Separator + Null
 
 // Resolve resolves a single template string using the request context
 func (rc *RequestContext) Resolve(ctx context.Context, templateStr string) (string, error) {
-	tmpl, err := rc.createTemplate(templateStr, nil)
+	tmpl, err := rc.createTemplate(ctx, templateStr, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating template: %w", err)
 	}
@@ -61,8 +61,22 @@ func (rc *RequestContext) ResolveBatch(ctx context.Context, templates ...string)
 	return results, nil
 }
 
-// createTemplate creates a template with all functions available
-func (rc *RequestContext) createTemplate(in string, funcMap template.FuncMap) (*template.Template, error) {
+// createTemplate creates a template with all functions available.
+//
+// ctx supplies the per-call function overlay (see WithTemplateFuncs), which
+// sits between the request-scoped functions and an explicit caller funcMap:
+// base -> request-scoped -> ctx overlay -> caller.
+func (rc *RequestContext) createTemplate(ctx context.Context, in string, funcMap template.FuncMap) (*template.Template, error) {
+	if overlay := templateFuncsFromContext(ctx); len(overlay) > 0 {
+		merged := make(template.FuncMap, len(overlay)+len(funcMap))
+		for name, fn := range overlay {
+			merged[name] = fn
+		}
+		for name, fn := range funcMap {
+			merged[name] = fn
+		}
+		funcMap = merged
+	}
 	funcMap = rc.getFuncMap(funcMap)
 	replaced := replaceEscapedQuotes(in)
 	replaced = normalizeActionVariables(replaced)


### PR DESCRIPTION
## What

Two additive pieces so a caller can run a single registered action without building a plan:

- **`actions.Runner`** — constructs the executable from the registry, resolves the config, and hides the v1/v2 split. Lifecycle matches the planner's: construct once, resolve per execution. A v1 action gets its `Config()` template rendered and passed as `modifiedConfig`; a v2 action resolves its own config and receives `ctx` untouched.
- **`requestctx.WithTemplateFuncs`** — template functions scoped to a context rather than to the request.

## Why the context overlay

A per-call function (a tool-argument reader) is only correct for the one call it was created for. Registering it on the shared `RequestContext` with `AddRequestTemplateFunctions` means concurrent calls overwrite each other's arguments. Carrying it on the ctx makes each call independent; `TestWithTemplateFuncs_ConcurrentCallsAreIndependent` covers exactly that.

`Resolve` and `ResolveBatch` already accepted a `ctx` and ignored it for functions. Now `createTemplate` takes the ctx and merges the overlay between the request-scoped functions and an explicit caller map: base → request-scoped → ctx overlay → caller. No exported signature changes.

## Motivation

servflow-pro is adding an `action` agent-tool type: one engine action offered to a model as a tool, with `{{ tool_param "x" }}` reading the model's arguments. The alternative was pro reimplementing construction, resolution, and the generation split against the registry — engine concepts that belong here. It also avoids a correctness trap: pre-resolving config in the caller and handing the result to a v2 constructor makes the action's own resolution run a second time over already-resolved text.

## Not changed

`plan/action.go` and `plan/action_v2.go` keep their own paths. Refactoring them onto `Runner` is a follow-up, kept out of this PR so nothing on the serving path moves.

## Tests

- `pkg/engine/requestctx/templatefuncs_test.go` — overlay visible to `Resolve`, `ResolveBatch`, `CreateTextTemplate`; composes with request functions, variables, and base functions; explicit caller map wins; nested overlays compose; sibling contexts stay isolated; 50 concurrent resolutions each see their own argument.
- `pkg/engine/actions/runner_test.go` — unregistered type and constructor errors fail at build; v1 receives the rendered config; v2 resolves its own; both see the ctx overlay; empty v1 config is not resolved; a resolution failure never reaches the action; execution errors and trace fields pass through.

Full suite green, `requestctx` also under `-race`.