### PR TITLE
Let the agent decide what a trace says about a conversation

### DIFF
--- a/pkg/agent/structure.go
+++ b/pkg/agent/structure.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
@@ -59,34 +58,6 @@ type LLMRequest struct {
 	Instruction   string
 	Messages      []any
 	Tools         []ToolInfo `json:"tools"`
-}
-
-// TraceMessages renders the request messages as a compact JSON array for
-// tracing (role + textual content only; no image bytes). Best-effort — returns
-// "" if it cannot marshal.
-func TraceMessages(messages []any) string {
-	type traced struct {
-		Role    string `json:"role,omitempty"`
-		Content string `json:"content,omitempty"`
-		Tool    string `json:"tool,omitempty"`
-	}
-	out := make([]traced, 0, len(messages))
-	for _, msg := range messages {
-		switch v := msg.(type) {
-		case MessageTypeContent:
-			out = append(out, traced{Role: v.Role.String(), Content: v.Content})
-		case MessageToolCall:
-			args, _ := json.Marshal(v.Arguments)
-			out = append(out, traced{Role: "assistant", Tool: v.Name, Content: string(args)})
-		case MessageToolCallResponse:
-			out = append(out, traced{Role: "tool", Tool: v.ID, Content: v.Text})
-		}
-	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }
 
 type ToolInfo struct {

--- a/pkg/engine/integration/integrations/claude/claude.go
+++ b/pkg/engine/integration/integrations/claude/claude.go
@@ -66,7 +66,6 @@ func (c *Client) ProvideResponse(ctx context.Context, agentReq agent.LLMRequest)
 
 	ctx, inf := tracing.StartInference(ctx, "anthropic", c.model)
 	defer func() { inf.End(ctx, err) }()
-	inf.SetInput(buildSystemPrompt(agentReq.SystemMessage, agentReq.Instruction), agent.TraceMessages(agentReq.Messages))
 
 	response, err := c.client.Messages.New(ctx, params)
 	if err != nil {
@@ -78,7 +77,6 @@ func (c *Client) ProvideResponse(ctx context.Context, agentReq agent.LLMRequest)
 	inf.RecordUsage(ctx, response.Usage.InputTokens, response.Usage.OutputTokens)
 
 	resp = convertSDKResponseToAgentResponse(response, logger)
-	inf.SetCompletion(resp.Text())
 	return resp, nil
 }
 

--- a/pkg/engine/integration/integrations/openai/openai.go
+++ b/pkg/engine/integration/integrations/openai/openai.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 
 	"github.com/Servflow/servflow/pkg/agent"
 	"github.com/Servflow/servflow/pkg/engine/integration"
@@ -58,7 +57,6 @@ func (c *Client) ProvideResponse(ctx context.Context, agentReq agent.LLMRequest)
 
 	ctx, inf := tracing.StartInference(ctx, "openai", c.model)
 	defer func() { inf.End(ctx, err) }()
-	inf.SetInput(buildSystemInstructions(agentReq.SystemMessage, agentReq.Instruction), agent.TraceMessages(agentReq.Messages))
 
 	response, err := c.client.Responses.New(ctx, params)
 	if err != nil {
@@ -70,20 +68,7 @@ func (c *Client) ProvideResponse(ctx context.Context, agentReq agent.LLMRequest)
 	inf.RecordUsage(ctx, response.Usage.InputTokens, response.Usage.OutputTokens)
 
 	resp = convertSDKResponseToAgentResponse(response, logger)
-	inf.SetCompletion(resp.Text())
 	return resp, nil
-}
-
-// buildSystemInstructions joins the system message and instruction for tracing.
-func buildSystemInstructions(systemMessage, instruction string) string {
-	parts := make([]string, 0, 2)
-	if s := strings.TrimSpace(systemMessage); s != "" {
-		parts = append(parts, s)
-	}
-	if s := strings.TrimSpace(instruction); s != "" {
-		parts = append(parts, s)
-	}
-	return strings.Join(parts, "\n\n")
 }
 
 func init() {

--- a/pkg/tracing/genai.go
+++ b/pkg/tracing/genai.go
@@ -2,7 +2,6 @@ package tracing
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -26,28 +25,7 @@ const (
 	AttrGenAIToolName      = "gen_ai.tool.name"
 	AttrGenAIToolType      = "gen_ai.tool.type" // mcp | workflow
 	AttrGenAIAgentName     = "gen_ai.agent.name"
-
-	// Message-content keys, recorded only when content capture is enabled.
-	AttrGenAISystemInstr    = "gen_ai.system_instructions"
-	AttrGenAIInputMessages  = "gen_ai.input.messages"
-	AttrGenAIOutputMessages = "gen_ai.output.messages"
 )
-
-// captureContent gates recording of prompt/response CONTENT onto chat spans.
-// Off by default (content may hold PII/secrets and is large); enable per the
-// OTel-standard env var. Read once at init; tests may set it directly.
-var captureContent = os.Getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT") == "true"
-
-// maxContentBytes caps each captured content attribute so a large context
-// window cannot bloat every span.
-const maxContentBytes = 8 * 1024
-
-func truncateContent(s string) string {
-	if len(s) <= maxContentBytes {
-		return s
-	}
-	return s[:maxContentBytes] + "…[truncated]"
-}
 
 const (
 	opChat        = "chat"
@@ -83,6 +61,10 @@ func initGenAIInstruments(mp metric.MeterProvider) {
 // timing for the operation-duration metric. Create one at the integration
 // boundary via StartInference, then SetResponseModel/RecordUsage on success and
 // End (always, via defer) to close the span and emit the duration metric.
+//
+// A chat span carries no message content. Prompts and replies are the caller's
+// to record: the agent owns that decision and does it on its own spans, so a
+// provider never has to know whether content capture is wanted.
 type Inference struct {
 	span     trace.Span
 	provider string
@@ -107,33 +89,6 @@ func (i *Inference) SetResponseModel(model string) {
 	if model != "" {
 		i.span.SetAttributes(attribute.String(AttrGenAIResponseModel, model))
 	}
-}
-
-// SetInput records the system instructions and input messages on the chat span.
-// No-op unless content capture is enabled; each field is size-capped.
-func (i *Inference) SetInput(system, messages string) {
-	if !captureContent {
-		return
-	}
-	attrs := make([]attribute.KeyValue, 0, 2)
-	if system != "" {
-		attrs = append(attrs, attribute.String(AttrGenAISystemInstr, truncateContent(system)))
-	}
-	if messages != "" {
-		attrs = append(attrs, attribute.String(AttrGenAIInputMessages, truncateContent(messages)))
-	}
-	if len(attrs) > 0 {
-		i.span.SetAttributes(attrs...)
-	}
-}
-
-// SetCompletion records the model's response content on the chat span. No-op
-// unless content capture is enabled; size-capped.
-func (i *Inference) SetCompletion(output string) {
-	if !captureContent || output == "" {
-		return
-	}
-	i.span.SetAttributes(attribute.String(AttrGenAIOutputMessages, truncateContent(output)))
 }
 
 // RecordUsage sets the token-usage span attributes and emits the token-usage

--- a/pkg/tracing/genai_test.go
+++ b/pkg/tracing/genai_test.go
@@ -144,43 +144,6 @@ func TestRequestTokensAggregateOntoRoot(t *testing.T) {
 	}
 }
 
-func TestContentCaptureGate(t *testing.T) {
-	sr := tracetest.NewSpanRecorder()
-	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
-	tracer = otel.Tracer("servflow-test")
-
-	// Default: capture disabled -> no content attributes.
-	captureContent = false
-	_, inf := StartInference(context.Background(), "anthropic", "m")
-	inf.SetInput("you are helpful", `[{"role":"user","content":"hi"}]`)
-	inf.SetCompletion("hello there")
-	inf.End(context.Background(), nil)
-
-	// Enabled -> content recorded.
-	captureContent = true
-	defer func() { captureContent = false }()
-	_, inf2 := StartInference(context.Background(), "anthropic", "m")
-	inf2.SetInput("you are helpful", `[{"role":"user","content":"hi"}]`)
-	inf2.SetCompletion("hello there")
-	inf2.End(context.Background(), nil)
-
-	ended := sr.Ended()
-	off := attrMap(ended[0].Attributes())
-	if _, ok := off[AttrGenAIInputMessages]; ok {
-		t.Error("input messages recorded while capture disabled")
-	}
-	if _, ok := off[AttrGenAIOutputMessages]; ok {
-		t.Error("output recorded while capture disabled")
-	}
-	on := attrMap(ended[1].Attributes())
-	if on[AttrGenAISystemInstr] != "you are helpful" {
-		t.Errorf("system_instructions = %v", on[AttrGenAISystemInstr])
-	}
-	if on[AttrGenAIOutputMessages] != "hello there" {
-		t.Errorf("output = %v", on[AttrGenAIOutputMessages])
-	}
-}
-
 func attrMap(kvs []attribute.KeyValue) map[string]interface{} {
 	out := make(map[string]interface{}, len(kvs))
 	for _, kv := range kvs {

--- a/pkg/tracing/spans.go
+++ b/pkg/tracing/spans.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/Servflow/servflow/pkg/engine/requestctx"
@@ -67,6 +68,10 @@ const (
 	AttrToolName     = "sf.tool_name"
 	AttrToolType     = "sf.tool_type"   // mcp | workflow
 	AttrToolParams   = "sf.tool_params" // JSON of model-supplied tool-call arguments (sensitive keys redacted, size-capped)
+
+	AttrAgentTurn          = "sf.agent.turn"           // 1-based iteration of the agent's tool-calling loop
+	AttrAgentTurnTools     = "sf.agent.turn_tools"     // tool names the model asked for on this turn
+	AttrAgentToolsWithheld = "sf.agent.tools_withheld" // tools were withheld to force a final answer
 
 	AttrRequestID = requestctx.AttrRequestID // stamped on the root span via the rc
 )
@@ -205,6 +210,22 @@ func StartAgentInvoke(ctx context.Context, name string) (context.Context, trace.
 		attrs = append(attrs, attribute.String(AttrGenAIAgentName, name))
 	}
 	return start(ctx, "invoke_agent", display, attrs...)
+}
+
+// StartAgentTurn spans one iteration of the agent's tool-calling loop: a single
+// model call plus the tools that call asked for. It groups them, so a trace
+// shows which tool runs belonged to which model call instead of leaving both
+// flat under invoke_agent.
+//
+// It carries no gen_ai.operation.name. A turn is wider than an inference and
+// narrower than the run, so it matches no GenAI operation, and claiming one
+// would misfile it for any backend that reads the conventions.
+//
+// The turn number labels the span; its child chat span carries the model and
+// the tokens, so those are deliberately not repeated here.
+func StartAgentTurn(ctx context.Context, turn int) (context.Context, trace.Span) {
+	return start(ctx, "Agent Turn", fmt.Sprintf("turn %d", turn),
+		attribute.Int(AttrAgentTurn, turn))
 }
 
 // StartMCPTool spans the invocation of an MCP tool. Carries both the sf.* tool


### PR DESCRIPTION
A `chat` span recorded prompts and replies behind `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`, read once at startup, here in the engine. That put the decision in the wrong repo: the caller that knows whether content is wanted is the agent, and it lives in pro.

The switch also only ever covered half the ground. It guarded the `chat` span, while the agent action published the same prompts through `sf.config` with no gate at all — and then stopped publishing anything when it moved to V2, which is the regression this unblocks.

## What changes

A `chat` span carries the model, the tokens, the duration and the error status, and nothing that was said. `SetInput`, `SetCompletion`, the three `gen_ai.*` content keys, the 8 KB cap, `captureContent` and `agent.TraceMessages` are all deleted, along with `TestContentCaptureGate`, which covered nothing but the gate. `Inference` is left as a recorder of what only a provider can know.

`StartAgentTurn` is new. It lets the agent group one iteration of its loop — a single model call plus the tools that call asked for. Both already emit spans, but flat under `invoke_agent`, so nothing said which tool runs belonged to which model call.

It deliberately carries no `gen_ai.operation.name`. A turn is wider than an inference and narrower than the run, so it matches no operation the GenAI conventions define, and claiming one would misfile it for any backend that reads them. That is also why the content it could have carried is not simply moved onto it under borrowed `gen_ai.input.messages` keys.

The legacy `claude` and `openai` integrations under `pkg/engine/integration/` lose their content calls too. They pair with the agent action under `executables/`, which nothing in either repo registers any more.

## Caller side

pro implements the other half: the switch now lives in `internal/agent`, read per call so flipping it needs no restart, and the agent writes its own configuration and turn detail under `sf.*` keys.

`pkg/providers/README.md` and `CLAUDE.md` in pro both documented the deleted methods as required, and are updated in the same change.

## Verification

`go build ./...` and `go test ./...` pass across the repo.