### PR TITLE
Name an action's integration field for what it selects

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ actions:
     type: mongoquery
     config:
       collection: users
-      integrationID: mongo
+      integration: mongo
     next: response.success
 
 responses:

--- a/examples/db-agent/configs/db-agent.yaml
+++ b/examples/db-agent/configs/db-agent.yaml
@@ -22,7 +22,7 @@ actions:
   agent:
     type: agent
     config:
-      integrationID: my_openai_service
+      integration: my_openai_service
       userPrompt: '{{ param "query" }}'
       systemPrompt: |
         You are a helpful agent to assist the user interact and query data from a mongodb database.
@@ -47,7 +47,7 @@ actions:
       collection: users
       filter: '{{ tool_param "filter" | escape }}'
       projection: '{{ tool_param "projection" | escape }}'
-      integrationID: "my_database"
+      integration: "my_database"
 
 responses:
   "200":

--- a/examples/user-registration/configs/user-registration.yaml
+++ b/examples/user-registration/configs/user-registration.yaml
@@ -41,7 +41,7 @@ actions:
   checkExistingUser:
     type: fetch
     config:
-      integrationID: my_database
+      integration: my_database
       table: users
       filters:
         - field: email
@@ -61,7 +61,7 @@ actions:
   createUser:
     type: save
     config:
-      integrationID: my_database
+      integration: my_database
       table: users
       fields:
         email: '{{ param "email" }}'

--- a/pkg/engine/actions/executables/agent/exec.go
+++ b/pkg/engine/actions/executables/agent/exec.go
@@ -18,11 +18,11 @@ import (
 )
 
 type Config struct {
-	ToolConfigs   []ToolConfig        `json:"toolConfigs" yaml:"toolConfigs"`
-	SystemPrompt  string              `json:"systemPrompt" yaml:"systemPrompt"`
-	UserPrompt    string              `json:"userPrompt" yaml:"userPrompt"`
-	IntegrationID string              `json:"integrationID" yaml:"integrationID"`
-	FileUpload    apiconfig.FileInput `json:"fileUpload" yaml:"fileUpload"`
+	ToolConfigs  []ToolConfig        `json:"toolConfigs" yaml:"toolConfigs"`
+	SystemPrompt string              `json:"systemPrompt" yaml:"systemPrompt"`
+	UserPrompt   string              `json:"userPrompt" yaml:"userPrompt"`
+	Integration  string              `json:"integration" yaml:"integration"`
+	FileUpload   apiconfig.FileInput `json:"fileUpload" yaml:"fileUpload"`
 }
 type MCPServerConfig struct {
 	Endpoint string   `json:"endpoint" yaml:"endpoint"`
@@ -99,7 +99,7 @@ func (a *Agent) Execute(ctx context.Context) (interface{}, map[string]string, er
 		return nil, nil, err
 	}
 
-	ctx, span := tracing.StartAgentInvoke(ctx, a.config.IntegrationID)
+	ctx, span := tracing.StartAgentInvoke(ctx, a.config.Integration)
 	defer span.End()
 
 	fileInput, err := requestctx.GetFileFromContext(ctx, fileUpload)
@@ -134,11 +134,11 @@ func (a *Agent) Type() string {
 }
 
 func New(config Config) (*Agent, error) {
-	if config.IntegrationID == "" {
-		return nil, errors.New("IntegrationID is required")
+	if config.Integration == "" {
+		return nil, errors.New("integration is required")
 	}
 
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -195,10 +195,10 @@ func init() {
 			Placeholder: "User message or query",
 			Required:    false,
 		},
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "AI integration identifier",
+			Label:       "AI Integration",
+			Placeholder: "The AI provider integration to call",
 			Required:    true,
 		},
 	}

--- a/pkg/engine/actions/executables/authenticate/authenticate.go
+++ b/pkg/engine/actions/executables/authenticate/authenticate.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Config struct {
-	IntegrationID   string `json:"integrationID" yaml:"integrationID"`
+	Integration     string `json:"integration" yaml:"integration"`
 	DatabaseField   string `json:"databaseField" yaml:"databaseField"`
 	JWTKey          string `json:"jwtKey" yaml:"jwtKey"`
 	Token           string `json:"token" yaml:"token"`
@@ -33,21 +33,21 @@ type Action struct {
 }
 
 func New(config Config) (*Action, error) {
-	integrationID := config.IntegrationID
+	integrationRef := config.Integration
 	databaseField := config.DatabaseField
 
-	if integrationID == "" {
-		return nil, errors.New("integration ID required")
+	if integrationRef == "" {
+		return nil, errors.New("integration is required")
 	}
 	if databaseField == "" {
 		return nil, errors.New("database field required")
 	}
 
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
-	config.IntegrationID = ""
+	config.Integration = ""
 
 	u, ok := i.(fetchImplementation)
 	if !ok {
@@ -119,10 +119,10 @@ func (a *Action) Type() string {
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Database integration identifier",
+			Label:       "User Database",
+			Placeholder: "The SQL or MongoDB integration holding the user records",
 			Required:    true,
 		},
 		"databaseField": {

--- a/pkg/engine/actions/executables/authenticate/authenticate_test.go
+++ b/pkg/engine/actions/executables/authenticate/authenticate_test.go
@@ -19,12 +19,12 @@ func TestAuthenticate_New(t *testing.T) {
 			DatabaseField: "email",
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "integration ID required")
+		assert.Contains(t, err.Error(), "integration is required")
 	})
 
 	t.Run("missing database field", func(t *testing.T) {
 		_, err := New(Config{
-			IntegrationID: "testintegration",
+			Integration: "testintegration",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "database field required")
@@ -35,7 +35,7 @@ func TestAuthenticate_New(t *testing.T) {
 		defer ctr.Finish()
 
 		_, err := New(Config{
-			IntegrationID: "nonexistent",
+			Integration:   "nonexistent",
 			DatabaseField: "email",
 		})
 		require.Error(t, err)
@@ -55,7 +55,7 @@ func TestAuthenticate_New(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = New(Config{
-			IntegrationID: "invalidds",
+			Integration:   "invalidds",
 			DatabaseField: "email",
 		})
 		require.Error(t, err)
@@ -76,7 +76,7 @@ func TestAuthenticate_New(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: "email",
 			JWTKey:        "secret",
 			Token:         "",
@@ -127,7 +127,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: dbField,
 			JWTKey:        jwtKey,
 			Collection:    collection,
@@ -163,7 +163,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: "email",
 			JWTKey:        "secret",
 			Collection:    "users",
@@ -197,7 +197,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: "email",
 			JWTKey:        "correct-secret",
 			Collection:    "users",
@@ -242,7 +242,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: "email",
 			JWTKey:        string(jwtKeyBytes),
 			Collection:    "users",
@@ -286,7 +286,7 @@ func TestAuthenticate_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		auth, err := New(Config{
-			IntegrationID: "mockds",
+			Integration:   "mockds",
 			DatabaseField: dbField,
 			JWTKey:        jwtKey,
 			Collection:    collection,
@@ -318,7 +318,7 @@ func TestAuthenticate_Type(t *testing.T) {
 
 func TestAuthenticate_Config(t *testing.T) {
 	config := Config{
-		IntegrationID: "testid",
+		Integration:   "testid",
 		DatabaseField: "email",
 		JWTKey:        "secret",
 		Token:         "token",

--- a/pkg/engine/actions/executables/delete_action/delete.go
+++ b/pkg/engine/actions/executables/delete_action/delete.go
@@ -30,7 +30,7 @@ func (d *Delete) Type() string {
 }
 
 type Config struct {
-	IntegrationID     string            `json:"integrationID"`
+	Integration       string            `json:"integration"`
 	Filters           []filters.Filter  `json:"filters"`
 	Table             string            `json:"table"`
 	DatasourceOptions map[string]string `json:"datasourceOptions"`
@@ -42,13 +42,13 @@ type deleteImplementation interface {
 }
 
 func New(config Config) (*Delete, error) {
-	if config.IntegrationID == "" {
+	if config.Integration == "" {
 		return nil, errors.New("datasource is required")
 	}
 	if config.Table == "" {
 		return nil, errors.New("table is required")
 	}
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -79,10 +79,10 @@ func (d *Delete) Execute(ctx context.Context, modifiedConfig string) (interface{
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Database integration identifier",
+			Label:       "Database Integration",
+			Placeholder: "The SQL or MongoDB integration to delete from",
 			Required:    true,
 		},
 		"filters": {

--- a/pkg/engine/actions/executables/delete_action/delete_test.go
+++ b/pkg/engine/actions/executables/delete_action/delete_test.go
@@ -25,7 +25,7 @@ func TestNewDeleteAction(t *testing.T) {
 	require.NoError(t, err)
 
 	del, err := New(Config{
-		IntegrationID:     "testID",
+		Integration:       "testID",
 		Table:             "mock_table",
 		DatasourceOptions: map[string]string{"optiontest": "test"},
 		Filters: []filters.Filter{
@@ -67,7 +67,7 @@ func TestDelete_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := New(Config{
-			IntegrationID:     "mockds",
+			Integration:       "mockds",
 			Table:             "mock_table",
 			DatasourceOptions: map[string]string{"optiontest": "test"},
 			Filters: []filters.Filter{
@@ -104,7 +104,7 @@ func TestDelete_Execute(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		d, err := New(Config{
-			IntegrationID:     "mockds",
+			Integration:       "mockds",
 			Table:             "mock_table",
 			DatasourceOptions: map[string]string{"optiontest": "test"},
 			Filters: []filters.Filter{
@@ -135,7 +135,7 @@ func TestDelete_Execute(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		d, err := New(Config{
-			IntegrationID:     "mockds",
+			Integration:       "mockds",
 			Table:             "mock_table",
 			DatasourceOptions: map[string]string{"optiontest": "test"},
 			Filters: []filters.Filter{
@@ -171,7 +171,7 @@ func TestDelete_Execute(t *testing.T) {
 
 	t.Run("missing table", func(t *testing.T) {
 		_, err := New(Config{
-			IntegrationID:     "mockds",
+			Integration:       "mockds",
 			DatasourceOptions: map[string]string{"optiontest": "test"},
 			Filters: []filters.Filter{
 				{

--- a/pkg/engine/actions/executables/fetch/fetch.go
+++ b/pkg/engine/actions/executables/fetch/fetch.go
@@ -29,21 +29,21 @@ type fetchImplementation interface {
 }
 
 type Config struct {
-	IntegrationID string           `json:"integrationID" yaml:"integrationID"`
-	Filters       []filters.Filter `json:"filters" yaml:"filters"`
-	Table         string           `json:"table" yaml:"table"`
-	Single        bool             `json:"single" yaml:"single"`
-	FailIfEmpty   bool             `json:"failIfEmpty" yaml:"failIfEmpty"`
+	Integration string           `json:"integration" yaml:"integration"`
+	Filters     []filters.Filter `json:"filters" yaml:"filters"`
+	Table       string           `json:"table" yaml:"table"`
+	Single      bool             `json:"single" yaml:"single"`
+	FailIfEmpty bool             `json:"failIfEmpty" yaml:"failIfEmpty"`
 }
 
 func New(config Config) (*Fetch, error) {
-	if config.IntegrationID == "" {
+	if config.Integration == "" {
 		return nil, errors.New("datasource is required")
 	}
 	if config.Table == "" {
 		return nil, errors.New("table is required")
 	}
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -95,10 +95,10 @@ func (f *Fetch) Execute(ctx context.Context, modifiedConfig string) (interface{}
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Database integration identifier",
+			Label:       "Database Integration",
+			Placeholder: "The SQL or MongoDB integration to read from",
 			Required:    true,
 		},
 		"filters": {

--- a/pkg/engine/actions/executables/fetch/fetch_test.go
+++ b/pkg/engine/actions/executables/fetch/fetch_test.go
@@ -32,8 +32,8 @@ func TestFetch_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		fetch, err := New(Config{
-			Table:         "mock",
-			IntegrationID: "mockds",
+			Table:       "mock",
+			Integration: "mockds",
 			Filters: []filters.Filter{
 				{
 					Field:      "id",
@@ -61,8 +61,8 @@ func TestFetch_Execute(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		fetch, err := New(Config{
-			Table:         "mock",
-			IntegrationID: "mockds",
+			Table:       "mock",
+			Integration: "mockds",
 			Filters: []filters.Filter{
 				{
 					Field:      "id",
@@ -89,9 +89,9 @@ func TestFetch_Execute(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		fetch, err := New(Config{
-			Table:         "mock",
-			IntegrationID: "mockds",
-			FailIfEmpty:   true,
+			Table:       "mock",
+			Integration: "mockds",
+			FailIfEmpty: true,
 			Filters: []filters.Filter{
 				{
 					Field:      "id",

--- a/pkg/engine/actions/executables/fetchvector/fetchvector.go
+++ b/pkg/engine/actions/executables/fetchvector/fetchvector.go
@@ -18,9 +18,9 @@ type fetchVectorIntegration interface {
 // TODO unify fields accross all integration actions
 
 type Config struct {
-	IntegrationID string         `json:"integrationID,omitempty"`
-	Vector        string         `json:"vector,omitempty"`
-	Options       map[string]any `json:"options,omitempty"`
+	Integration string         `json:"integration,omitempty"`
+	Vector      string         `json:"vector,omitempty"`
+	Options     map[string]any `json:"options,omitempty"`
 }
 
 type FetchVector struct {
@@ -63,10 +63,10 @@ func (f FetchVector) Execute(ctx context.Context, modifiedConfig string) (interf
 }
 
 func New(config Config) (*FetchVector, error) {
-	if config.IntegrationID == "" {
+	if config.Integration == "" {
 		return nil, fmt.Errorf("no integration ID provided")
 	}
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +84,11 @@ func New(config Config) (*FetchVector, error) {
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Vector database integration identifier",
-			Required:    false,
+			Label:       "Vector Database",
+			Placeholder: "The vector store to search",
+			Required:    true,
 		},
 		"vector": {
 			Type:        actions.FieldTypeString,

--- a/pkg/engine/actions/executables/fetchvector/fetchvector_test.go
+++ b/pkg/engine/actions/executables/fetchvector/fetchvector_test.go
@@ -38,8 +38,8 @@ func TestFetchVector_Execute(t *testing.T) {
 
 		fetchVectorObj := FetchVector{
 			cfg: &Config{
-				IntegrationID: "mockid",
-				Vector:        string(jsonVectors),
+				Integration: "mockid",
+				Vector:      string(jsonVectors),
 			},
 			fetchIntegration: mockIntegration,
 		}
@@ -74,9 +74,9 @@ func TestFetchVector_Execute(t *testing.T) {
 
 		fetchVectorObj := FetchVector{
 			cfg: &Config{
-				IntegrationID: "mockid",
-				Vector:        string(jsonVectors),
-				Options:       options,
+				Integration: "mockid",
+				Vector:      string(jsonVectors),
+				Options:     options,
 			},
 			fetchIntegration: mockIntegration,
 		}

--- a/pkg/engine/actions/executables/mongoquery/mongoquery.go
+++ b/pkg/engine/actions/executables/mongoquery/mongoquery.go
@@ -12,11 +12,11 @@ import (
 )
 
 type Config struct {
-	Collection    string `json:"collection" yaml:"collection"`
-	FilterQuery   string `json:"filterQuery" yaml:"filterQuery"`
-	Projection    string `json:"projection" yaml:"projection"`
-	IntegrationID string `json:"integrationID" yaml:"integrationID"`
-	FailIfEmpty   bool   `json:"failIfEmpty" yaml:"failIfEmpty"`
+	Collection  string `json:"collection" yaml:"collection"`
+	FilterQuery string `json:"filterQuery" yaml:"filterQuery"`
+	Projection  string `json:"projection" yaml:"projection"`
+	Integration string `json:"integration" yaml:"integration"`
+	FailIfEmpty bool   `json:"failIfEmpty" yaml:"failIfEmpty"`
 }
 
 type mongoDBIntegration interface {
@@ -37,14 +37,14 @@ func (m *MGOQuery) Config() string {
 }
 
 func New(config Config) (*MGOQuery, error) {
-	if config.IntegrationID == "" {
-		return nil, errors.New("IntegrationID is required")
+	if config.Integration == "" {
+		return nil, errors.New("integration is required")
 	}
 	if config.Collection == "" {
 		return nil, errors.New("collection is required")
 	}
 
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -104,10 +104,10 @@ func init() {
 			Placeholder: "MongoDB projection query",
 			Required:    false,
 		},
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "MongoDB integration identifier",
+			Label:       "MongoDB Integration",
+			Placeholder: "The MongoDB integration to query",
 			Required:    true,
 		},
 		"failIfEmpty": {

--- a/pkg/engine/actions/executables/save/save.go
+++ b/pkg/engine/actions/executables/save/save.go
@@ -23,7 +23,7 @@ type saveIntegration interface {
 }
 
 type Config struct {
-	IntegrationID     string                 `json:"integrationID"`
+	Integration       string                 `json:"integration"`
 	Table             string                 `json:"table"`
 	DatasourceOptions map[string]string      `json:"datasourceOptions"`
 	Fields            map[string]interface{} `json:"fields"`
@@ -40,14 +40,14 @@ func (s *Save) Type() string {
 }
 
 func New(config Config) (*Save, error) {
-	if config.IntegrationID == "" {
-		return nil, errors.New("integrationID is required")
+	if config.Integration == "" {
+		return nil, errors.New("integration is required")
 	}
 	if config.Table == "" {
 		return nil, errors.New("table is required")
 	}
 
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -174,10 +174,10 @@ func (s *Save) resolveFilters(ctx context.Context, rc *requestctx.RequestContext
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Database integration identifier",
+			Label:       "Database Integration",
+			Placeholder: "The SQL or MongoDB integration to write to",
 			Required:    true,
 		},
 		"table": {

--- a/pkg/engine/actions/executables/save/save_test.go
+++ b/pkg/engine/actions/executables/save/save_test.go
@@ -36,9 +36,9 @@ func TestSave_Insert(t *testing.T) {
 		require.NoError(t, err)
 
 		save, err := New(Config{
-			IntegrationID: "mockds",
-			Table:         "mock_table",
-			Fields:        map[string]interface{}{"id": "test-id", "name": "test"},
+			Integration: "mockds",
+			Table:       "mock_table",
+			Fields:      map[string]interface{}{"id": "test-id", "name": "test"},
 		})
 		require.NoError(t, err)
 
@@ -64,9 +64,9 @@ func TestSave_Insert(t *testing.T) {
 		require.NoError(t, err)
 
 		save, err := New(Config{
-			IntegrationID: "mockds",
-			Table:         "mock_table",
-			Fields:        map[string]interface{}{"name": "test"},
+			Integration: "mockds",
+			Table:       "mock_table",
+			Fields:      map[string]interface{}{"name": "test"},
 		})
 		require.NoError(t, err)
 
@@ -94,9 +94,9 @@ func TestSave_Insert(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		save, err := New(Config{
-			IntegrationID: "mockds",
-			Table:         "mock_table",
-			Fields:        map[string]interface{}{"name": "test"},
+			Integration: "mockds",
+			Table:       "mock_table",
+			Fields:      map[string]interface{}{"name": "test"},
 		})
 		require.NoError(t, err)
 
@@ -133,10 +133,10 @@ func TestSave_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		save, err := New(Config{
-			IntegrationID: "mockds",
-			Table:         "mock_table",
-			Fields:        map[string]interface{}{"name": "updated"},
-			Filters:       filtersList,
+			Integration: "mockds",
+			Table:       "mock_table",
+			Fields:      map[string]interface{}{"name": "updated"},
+			Filters:     filtersList,
 		})
 		require.NoError(t, err)
 
@@ -164,10 +164,10 @@ func TestSave_Update(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockds", nil)
 
 		save, err := New(Config{
-			IntegrationID: "mockds",
-			Table:         "mock_table",
-			Fields:        map[string]interface{}{"name": "updated"},
-			Filters:       filtersList,
+			Integration: "mockds",
+			Table:       "mock_table",
+			Fields:      map[string]interface{}{"name": "updated"},
+			Filters:     filtersList,
 		})
 		require.NoError(t, err)
 
@@ -178,19 +178,19 @@ func TestSave_Update(t *testing.T) {
 }
 
 func TestSave_Validation(t *testing.T) {
-	t.Run("missing integrationID", func(t *testing.T) {
+	t.Run("missing integration", func(t *testing.T) {
 		_, err := New(Config{
 			Table:  "mock_table",
 			Fields: map[string]interface{}{"name": "test"},
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "integrationID is required")
+		assert.Contains(t, err.Error(), "integration is required")
 	})
 
 	t.Run("missing table", func(t *testing.T) {
 		_, err := New(Config{
-			IntegrationID: "mockds",
-			Fields:        map[string]interface{}{"name": "test"},
+			Integration: "mockds",
+			Fields:      map[string]interface{}{"name": "test"},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "table is required")
@@ -208,9 +208,9 @@ func TestSave_Type(t *testing.T) {
 	integration.InitializeIntegration("mock", "mockds", nil)
 
 	save, err := New(Config{
-		IntegrationID: "mockds",
-		Table:         "mock_table",
-		Fields:        map[string]interface{}{"name": "test"},
+		Integration: "mockds",
+		Table:       "mock_table",
+		Fields:      map[string]interface{}{"name": "test"},
 	})
 	require.NoError(t, err)
 

--- a/pkg/engine/actions/executables/storevector/storevector.go
+++ b/pkg/engine/actions/executables/storevector/storevector.go
@@ -16,10 +16,10 @@ type storeVectorIntegration interface {
 }
 
 type Config struct {
-	IntegrationID string            `json:"integrationID,omitempty"`
-	Fields        map[string]any    `json:"fields"`
-	Options       map[string]string `json:"options,omitempty"`
-	Vectors       string            `json:"vectors"`
+	Integration string            `json:"integration,omitempty"`
+	Fields      map[string]any    `json:"fields"`
+	Options     map[string]string `json:"options,omitempty"`
+	Vectors     string            `json:"vectors"`
 }
 
 type StoreVectors struct {
@@ -34,7 +34,7 @@ func (s StoreVectors) Type() string {
 func (s StoreVectors) Config() string {
 	cfg := *s.cfg
 	cfg.Options = nil
-	cfg.IntegrationID = ""
+	cfg.Integration = ""
 	dat, err := json.Marshal(cfg)
 	if err != nil {
 		return ""
@@ -64,10 +64,10 @@ func (s StoreVectors) Execute(ctx context.Context, modifiedConfig string) (inter
 }
 
 func New(config Config) (*StoreVectors, error) {
-	if config.IntegrationID == "" {
+	if config.Integration == "" {
 		return nil, fmt.Errorf("no integration ID provided")
 	}
-	i, err := integration.GetIntegration(context.Background(), config.IntegrationID)
+	i, err := integration.GetIntegration(context.Background(), config.Integration)
 	if err != nil {
 		return nil, err
 	}
@@ -85,11 +85,11 @@ func New(config Config) (*StoreVectors, error) {
 
 func init() {
 	fields := map[string]actions.FieldInfo{
-		"integrationID": {
+		"integration": {
 			Type:        actions.FieldTypeIntegration,
-			Label:       "Integration ID",
-			Placeholder: "Vector database integration identifier",
-			Required:    false,
+			Label:       "Vector Database",
+			Placeholder: "The vector store to write to",
+			Required:    true,
 		},
 		"fields": {
 			Type:        actions.FieldTypeMap,

--- a/pkg/engine/actions/executables/storevector/storevector_test.go
+++ b/pkg/engine/actions/executables/storevector/storevector_test.go
@@ -34,10 +34,10 @@ func TestStoreVectors_Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		storeVectors, err := New(Config{
-			IntegrationID: "mockid",
-			Fields:        fields,
-			Options:       map[string]string{"optiontest": "test"},
-			Vectors:       string(jsonVectors),
+			Integration: "mockid",
+			Fields:      fields,
+			Options:     map[string]string{"optiontest": "test"},
+			Vectors:     string(jsonVectors),
 		})
 		require.NoError(t, err)
 
@@ -63,10 +63,10 @@ func TestStoreVectors_Execute(t *testing.T) {
 		integration.InitializeIntegration("mock", "mockid", nil)
 
 		storeVectors, err := New(Config{
-			IntegrationID: "mockid",
-			Fields:        fields,
-			Options:       map[string]string{"optiontest": "test"},
-			Vectors:       string(jsonVectors),
+			Integration: "mockid",
+			Fields:      fields,
+			Options:     map[string]string{"optiontest": "test"},
+			Vectors:     string(jsonVectors),
 		})
 		require.NoError(t, err)
 

--- a/testsuite/compose/confs/create.yml
+++ b/testsuite/compose/confs/create.yml
@@ -16,7 +16,7 @@ actions:
   authenticate:
     type: authenticate
     config:
-      integrationID: mongo
+      integration: mongo
       databaseField: email
       jwtKey: "test"
       token: '{{ header "Authorization" }}'
@@ -27,7 +27,7 @@ actions:
   saveItem:
     type: store
     config:
-      integrationID: mongo
+      integration: mongo
       table: notes
       fields:
         title: '{{ param "title" }}'

--- a/testsuite/compose/confs/delete.yml
+++ b/testsuite/compose/confs/delete.yml
@@ -15,7 +15,7 @@ actions:
   authenticate:
     type: authenticate
     config:
-      integrationID: mongo
+      integration: mongo
       databaseField: email
       jwtKey: "test"
       token: '{{ header "Authorization" }}'
@@ -26,7 +26,7 @@ actions:
   deleteItem:
     type: delete
     config:
-      integrationID: mongo
+      integration: mongo
       table: notes
       filters:
         - field: id

--- a/testsuite/compose/confs/list.yml
+++ b/testsuite/compose/confs/list.yml
@@ -8,7 +8,7 @@ actions:
   authenticate:
     type: authenticate
     config:
-      integrationID: mongo
+      integration: mongo
       databaseField: email
       failOnAuthError: true
       jwtKey: "test"
@@ -19,7 +19,7 @@ actions:
   fetchItem:
     type: fetch
     config:
-      integrationID: mongo
+      integration: mongo
       table: notes
       failIfEmpty: true
       filters:

--- a/testsuite/compose/confs/login.yml
+++ b/testsuite/compose/confs/login.yml
@@ -24,7 +24,7 @@ actions:
     config:
       single: true
       failIfEmpty: true
-      integrationID: mongo
+      integration: mongo
       table: users
       filters:
         - field: email

--- a/testsuite/compose/confs/mcp_register.yml
+++ b/testsuite/compose/confs/mcp_register.yml
@@ -35,7 +35,7 @@ actions:
   fetchemail:
     type: fetch
     config:
-      integrationID: mongo
+      integration: mongo
       table: users
       filters:
         - field: email
@@ -53,7 +53,7 @@ actions:
   storedb:
     type: store
     config:
-      integrationID: mongo
+      integration: mongo
       table: users
       fields:
         email: '{{ tool_param "email" }}'
@@ -66,7 +66,7 @@ actions:
     config:
       failIfEmpty: true
       single: true
-      integrationID: mongo
+      integration: mongo
       table: users
       filters:
         - field: email

--- a/testsuite/compose/confs/read.yml
+++ b/testsuite/compose/confs/read.yml
@@ -15,7 +15,7 @@ actions:
   authenticate:
     type: authenticate
     config:
-      integrationID: mongo
+      integration: mongo
       databaseField: email
       failOnAuthError: true
       jwtKey: "test"
@@ -26,7 +26,7 @@ actions:
   fetchItem:
     type: fetch
     config:
-      integrationID: mongo
+      integration: mongo
       table: notes
       single: true
       failIfEmpty: true

--- a/testsuite/compose/confs/register.yml
+++ b/testsuite/compose/confs/register.yml
@@ -23,7 +23,7 @@ actions:
   fetchemail:
     type: fetch
     config:
-      integrationID: mongo
+      integration: mongo
       table: users
       filters:
         - field: email
@@ -41,7 +41,7 @@ actions:
   storedb:
     type: store
     config:
-      integrationID: mongo
+      integration: mongo
       table: users
       fields:
         email: '{{ param "email" }}'

--- a/testsuite/compose/confs/update.yml
+++ b/testsuite/compose/confs/update.yml
@@ -17,7 +17,7 @@ actions:
   authenticate:
     type: authenticate
     config:
-      integrationID: mongo
+      integration: mongo
       databaseField: email
       failOnAuthError: true
       jwtKey: "test"
@@ -28,7 +28,7 @@ actions:
   fetchItem:
     type: update
     config:
-      integrationID: mongo
+      integration: mongo
       table: notes
       single: true
       failIfEmpty: true


### PR DESCRIPTION
## What

Every action that needs an integration took `integrationID`, labelled "Integration ID". The name said what the value is (an id) rather than what it selects, so the form told an author nothing about which of their integrations belonged there. The newer actions in servflowai had already drifted to a plainer `integration` key, leaving two conventions.

The field is now `integration` on all eight actions, labelled for the thing it picks:

| Action | Label |
|---|---|
| `fetch`, `save`, `delete` | Database Integration |
| `authenticate` | User Database |
| `mongoquery` | MongoDB Integration |
| `fetchvectors`, `storevector` | Vector Database |
| `agent` | AI Integration |

Placeholders now say what the step does with the integration instead of restating the label.

`fetchvectors` and `storevector` declared the field optional while their constructors reject an empty one, so a config missing it passed validation and failed at build time. Both are `Required: true` now.

## Breaking

This renames a config key. A stored config written with `integrationID` fails validation with `missing required field "integration"` rather than silently losing its integration — except on the two vector actions, which were optional before this change and would have failed later, at build.

Configs in this repo (README, `examples/`, `testsuite/compose/confs/`) are updated. Stored configs in servflowai are migrated on that side; that branch must land only after this one is published and re-pinned.

## Test

`go build ./... && go test ./...` — all green.