### PR TITLE
Let a host reach the action a runner holds

### DIFF
--- a/pkg/engine/actions/runner.go
+++ b/pkg/engine/actions/runner.go
@@ -76,3 +76,18 @@ func (r *Runner) Execute(ctx context.Context) (resp interface{}, fields map[stri
 	}
 	return r.v1.Execute(ctx, resolved)
 }
+
+// Executable returns the constructed action, whichever generation this runner
+// holds.
+//
+// It is here because a host may want to ask the action for behaviour the
+// engine has no opinion about — an agent tool asks whether the action can
+// render its own output for a model to read — and asking should not mean
+// re-deriving which generation the action is. The host asserts its own
+// interface on what comes back; the engine defines none.
+func (r *Runner) Executable() any {
+	if r.v2 != nil {
+		return r.v2
+	}
+	return r.v1
+}

--- a/pkg/engine/actions/runner_test.go
+++ b/pkg/engine/actions/runner_test.go
@@ -235,3 +235,15 @@ func TestRunner_ReturnsTraceFields(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"url": "https://example.com"}, fields)
 }
+
+func TestRunner_ExecutableIsTheConstructedAction(t *testing.T) {
+	v1 := &runnerV1{}
+	r1, err := NewRunner(registerRunnerV1(t, "runner-exec-v1", v1), json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Same(t, v1, r1.Executable())
+
+	v2 := &runnerV2{}
+	r2, err := NewRunner(registerRunnerV2(t, "runner-exec-v2", v2), json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Same(t, v2, r2.Executable())
+}


### PR DESCRIPTION
## What

`Runner.Executable()` returns the constructed action, whichever generation the runner holds.

```go
func (r *Runner) Executable() any {
	if r.v2 != nil {
		return r.v2
	}
	return r.v1
}
```

## Why

A `Runner` constructs the executable and keeps the v1/v2 split away from its callers, which is what it exists for. That also leaves a caller with no way to ask the action anything the two interfaces do not already say.

servflowai needs to ask an action whether it can render its own output for a model to read. An agent tool sends an action's return value to a model, and for an action whose output is shaped for templates, JSON is the wrong artefact: `discord/readguild` returns 794 characters where 241 of prose say the same thing.

The engine defines no interface over what comes back. How an agent tool presents a result is not a question the engine has an opinion about, so the host declares and asserts its own interface. Go interfaces are structural, so no action package imports anything to satisfy it.

## Alternatives considered

- **The host constructs its own second executable** through the already-exported `IsV2Action` + `GetActionExecutable`/`GetActionExecutableV2`. Rejected: it makes every host re-learn the generation split the runner hides, and the instance that answers is not the instance that ran.
- **An interface in the engine.** Rejected: it would make the engine model tool presentation, and an engine-owned interface cannot be satisfied by a host-owned concern.

## Testing

`TestRunner_ExecutableIsTheConstructedAction` asserts both generations return the same instance the runner runs. Full `./pkg/engine/...` suite passes.
