### PR TITLE
Trace what the product did, on every span

### DIFF
--- a/pkg/engine/requestctx/aggregationcontext.go
+++ b/pkg/engine/requestctx/aggregationcontext.go
@@ -38,8 +38,8 @@ type RequestContext struct {
 	// Own mutex; never nil (see NewRequestContext).
 	secrets *secretTable
 
-	// spanAttrs are the request-wide attributes stamped on this request's root
-	// span by pkg/tracing. Set once in Start before the ctx is shared;
+	// spanAttrs are the request-wide attributes stamped on every span of this
+	// request by pkg/tracing. Set once in Start before the ctx is shared;
 	// read-only afterwards.
 	spanAttrs []attribute.KeyValue
 	// lc is the request completion latch (see lifecycle.go).

--- a/pkg/engine/requestctx/lifecycle.go
+++ b/pkg/engine/requestctx/lifecycle.go
@@ -15,7 +15,7 @@ import (
 // Span attribute keys owned by the request layer. pkg/tracing aliases them
 // (it imports this package; the reverse would cycle).
 const (
-	// AttrRequestID is stamped on the request's root span via SpanAttributes.
+	// AttrRequestID is stamped on every span of the request via SpanAttributes.
 	AttrRequestID = "sf.request_id"
 )
 

--- a/pkg/engine/server/mcp_handler.go
+++ b/pkg/engine/server/mcp_handler.go
@@ -79,12 +79,12 @@ func (e *Engine) createMCPHandler(config *apiconfig.APIConfig) error {
 			},
 			TemplateFuncsExclusive: true,
 		})
-		// The lifecycle owns the MCP root span (bound in StartMCPTool): Done
+		// The lifecycle owns the MCP root span (bound in StartMCPEntry): Done
 		// ends it once any dispatched chains drain.
 		defer reqCtx.Done()
 		logger := logging.FromContext(ctx)
 
-		ctx, _ = tracing.StartMCPTool(ctx, config.McpTool.Name) // lifecycle-owned; no manual End
+		ctx, _ = tracing.StartMCPEntry(ctx, config.McpTool.Name) // lifecycle-owned; no manual End
 
 		if _, err := p.Execute(ctx, config.McpTool.Start); err != nil {
 			logger.Error("error executing planner", zap.Error(err))

--- a/pkg/tracing/genai.go
+++ b/pkg/tracing/genai.go
@@ -76,7 +76,7 @@ type Inference struct {
 // duration clock. provider is the semconv gen_ai.provider.name value
 // ("anthropic", "openai"); model is the requested model id.
 func StartInference(ctx context.Context, provider, model string) (context.Context, *Inference) {
-	ctx, span := start(ctx, "chat", provider+" "+model,
+	ctx, span := createSpan(ctx, "chat", provider+" "+model,
 		attribute.String(AttrGenAIOperation, opChat),
 		attribute.String(AttrGenAIProvider, provider),
 		attribute.String(AttrGenAIRequestModel, model),

--- a/pkg/tracing/genai.go
+++ b/pkg/tracing/genai.go
@@ -72,11 +72,15 @@ type Inference struct {
 	start    time.Time
 }
 
-// StartInference opens a GenAI "chat" span around one model call and starts the
+// StartInference opens an "LLM Call" span around one model call and starts the
 // duration clock. provider is the semconv gen_ai.provider.name value
 // ("anthropic", "openai"); model is the requested model id.
+//
+// The span is named for what it is rather than for the GenAI operation it
+// reports. gen_ai.operation.name still carries chat, so a backend that reads
+// the conventions classifies it the same as before.
 func StartInference(ctx context.Context, provider, model string) (context.Context, *Inference) {
-	ctx, span := createSpan(ctx, "chat", provider+" "+model,
+	ctx, span := createSpan(ctx, "LLM Call", provider+" "+model,
 		attribute.String(AttrGenAIOperation, opChat),
 		attribute.String(AttrGenAIProvider, provider),
 		attribute.String(AttrGenAIRequestModel, model),

--- a/pkg/tracing/lifecycle_integration_test.go
+++ b/pkg/tracing/lifecycle_integration_test.go
@@ -30,7 +30,7 @@ func endedByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktr
 // TestLifecycleBinding_RootEndsAfterFlow proves the rc lifecycle owns the root
 // span end: a root bound via StartHTTPEntry stays un-ended after Done while a
 // child flow is open, then ends exactly once when the flow drains — covering
-// request-wide attr stamping on the root only (not children), token totals
+// request-wide attr stamping on every span of the request, token totals
 // stamped at end including late tokens, and root ⊇ child in time.
 func TestLifecycleBinding_RootEndsAfterFlow(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
@@ -69,13 +69,17 @@ func TestLifecycleBinding_RootEndsAfterFlow(t *testing.T) {
 	child := endedByName(t, ended, "Action")
 
 	rootAttrs := attrMap(root.Attributes())
-	// Request id + host attr live on the ROOT span only.
 	assert.Equal(t, "req-123", rootAttrs[requestctx.AttrRequestID])
 	assert.Equal(t, "AcctBot", rootAttrs["sf.agent"])
-	// Child spans do NOT carry the request-wide attributes.
+	// Child spans carry them too: the backend matches per span, so identity
+	// the root alone held could not narrow a search for one agent's spans.
 	childAttrs := attrMap(child.Attributes())
-	assert.NotContains(t, childAttrs, requestctx.AttrRequestID)
-	assert.NotContains(t, childAttrs, "sf.agent")
+	assert.Equal(t, "req-123", childAttrs[requestctx.AttrRequestID])
+	assert.Equal(t, "AcctBot", childAttrs["sf.agent"])
+
+	// The token totals stay on the root: they are a request aggregate, and the
+	// lifecycle stamps them once, on the span it owns.
+	assert.NotContains(t, childAttrs, AttrUsageTotal)
 
 	// Late tokens landed on the root (stamped by the beforeEnd hook).
 	assert.Equal(t, int64(150), rootAttrs[AttrUsageTotal])

--- a/pkg/tracing/spans.go
+++ b/pkg/tracing/spans.go
@@ -76,11 +76,11 @@ const (
 	AttrRequestID = requestctx.AttrRequestID // stamped on the root span via the rc
 )
 
-// start creates a span with a low-cardinality name and always attaches the
+// createSpan creates a span with a low-cardinality name and always attaches the
 // friendly display label as the AttrName attribute. All typed constructors
 // below funnel through here so no span can be created without a label — and,
 // when the context carries a RequestContext, without secret scrubbing.
-func start(ctx context.Context, spanName, display string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+func createSpan(ctx context.Context, spanName, display string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
 	ctx, span := tracer.Start(ctx, spanName)
 	if rc, ok := requestctx.FromContext(ctx); ok {
 		span = scrubSpan{Span: span, s: rc}
@@ -118,7 +118,7 @@ func rootDisplay(name, id string) string {
 // friendly display name and id its stable config id; both identify which
 // workflow the trace belongs to.
 func StartHTTPEntry(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	ctx, span := start(ctx, "HTTP Entry", rootDisplay(name, id),
+	ctx, span := createSpan(ctx, "HTTP Entry", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
 	bindRoot(ctx, span)
@@ -148,7 +148,7 @@ func SetHTTPStatus(span trace.Span, code int, err error) {
 
 // StartAction spans a plan action step. actionType is the concrete action type.
 func StartAction(ctx context.Context, id, name, actionType string) (context.Context, trace.Span) {
-	return start(ctx, "Action", name,
+	return createSpan(ctx, "Action", name,
 		attribute.String(AttrStepType, "action"),
 		attribute.String(AttrActionType, actionType),
 		attribute.String(AttrID, id))
@@ -156,14 +156,14 @@ func StartAction(ctx context.Context, id, name, actionType string) (context.Cont
 
 // StartCondition spans a plan condition step.
 func StartCondition(ctx context.Context, id, name string) (context.Context, trace.Span) {
-	return start(ctx, "Condition", name,
+	return createSpan(ctx, "Condition", name,
 		attribute.String(AttrStepType, "condition"),
 		attribute.String(AttrID, id))
 }
 
 // StartResponse spans a plan response step.
 func StartResponse(ctx context.Context, id, name string) (context.Context, trace.Span) {
-	return start(ctx, "Response", name,
+	return createSpan(ctx, "Response", name,
 		attribute.String(AttrStepType, "response"),
 		attribute.String(AttrID, id))
 }
@@ -171,7 +171,7 @@ func StartResponse(ctx context.Context, id, name string) (context.Context, trace
 // StartWorkflowExecute spans a workflow invoked through a trigger (e.g. callworkflow).
 // name is the workflow's friendly display name and id its stable config id.
 func StartWorkflowExecute(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	ctx, span := start(ctx, "Workflow Execute", rootDisplay(name, id),
+	ctx, span := createSpan(ctx, "Workflow Execute", rootDisplay(name, id),
 		attribute.String(AttrStepType, "trigger"),
 		attribute.String(AttrWorkflow, id))
 	bindRoot(ctx, span)
@@ -181,7 +181,7 @@ func StartWorkflowExecute(ctx context.Context, name, id string) (context.Context
 // StartScheduledExecution spans a scheduled (cron) workflow run.
 // name is the workflow's friendly display name and id its stable config id.
 func StartScheduledExecution(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	ctx, span := start(ctx, "Scheduled Execution", rootDisplay(name, id),
+	ctx, span := createSpan(ctx, "Scheduled Execution", rootDisplay(name, id),
 		attribute.String(AttrStepType, "scheduled"),
 		attribute.String(AttrWorkflow, id))
 	bindRoot(ctx, span)
@@ -191,7 +191,7 @@ func StartScheduledExecution(ctx context.Context, name, id string) (context.Cont
 // StartDashboardRun spans a manual workflow run triggered from the builder dashboard.
 // name is the workflow's friendly display name and id its stable config id.
 func StartDashboardRun(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	ctx, span := start(ctx, "Dashboard Run", rootDisplay(name, id),
+	ctx, span := createSpan(ctx, "Dashboard Run", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
 	bindRoot(ctx, span)
@@ -209,7 +209,7 @@ func StartAgentInvoke(ctx context.Context, name string) (context.Context, trace.
 	if name != "" {
 		attrs = append(attrs, attribute.String(AttrGenAIAgentName, name))
 	}
-	return start(ctx, "invoke_agent", display, attrs...)
+	return createSpan(ctx, "invoke_agent", display, attrs...)
 }
 
 // StartAgentTurn spans one iteration of the agent's tool-calling loop: a single
@@ -224,14 +224,14 @@ func StartAgentInvoke(ctx context.Context, name string) (context.Context, trace.
 // The turn number labels the span; its child chat span carries the model and
 // the tokens, so those are deliberately not repeated here.
 func StartAgentTurn(ctx context.Context, turn int) (context.Context, trace.Span) {
-	return start(ctx, "Agent Turn", fmt.Sprintf("turn %d", turn),
+	return createSpan(ctx, "Agent Turn", fmt.Sprintf("turn %d", turn),
 		attribute.Int(AttrAgentTurn, turn))
 }
 
 // StartMCPTool spans the invocation of an MCP tool. Carries both the sf.* tool
 // keys and the GenAI execute_tool attributes.
 func StartMCPTool(ctx context.Context, name string) (context.Context, trace.Span) {
-	ctx, span := start(ctx, "MCP Tool", name,
+	ctx, span := createSpan(ctx, "MCP Tool", name,
 		attribute.String(AttrToolName, name),
 		attribute.String(AttrToolType, "mcp"),
 		attribute.String(AttrGenAIOperation, opExecuteTool),
@@ -244,7 +244,7 @@ func StartMCPTool(ctx context.Context, name string) (context.Context, trace.Span
 // StartAgentTool spans the invocation of an agent workflow tool. Carries both
 // the sf.* tool keys and the GenAI execute_tool attributes.
 func StartAgentTool(ctx context.Context, identifier string) (context.Context, trace.Span) {
-	return start(ctx, "Tool Call", identifier,
+	return createSpan(ctx, "Tool Call", identifier,
 		attribute.String(AttrToolName, identifier),
 		attribute.String(AttrToolType, "workflow"),
 		attribute.String(AttrGenAIOperation, opExecuteTool),

--- a/pkg/tracing/spans.go
+++ b/pkg/tracing/spans.go
@@ -73,7 +73,7 @@ const (
 	AttrAgentTurnTools     = "sf.agent.turn_tools"     // tool names the model asked for on this turn
 	AttrAgentToolsWithheld = "sf.agent.tools_withheld" // tools were withheld to force a final answer
 
-	AttrRequestID = requestctx.AttrRequestID // stamped on the root span via the rc
+	AttrRequestID = requestctx.AttrRequestID // stamped on every span via the rc
 )
 
 // createSpan creates a span with a low-cardinality name and always attaches the
@@ -87,22 +87,46 @@ func createSpan(ctx context.Context, spanName, display string, attrs ...attribut
 		// Re-store the wrapped span so trace.SpanFromContext(ctx) callers also
 		// get the scrubbing wrapper, not the raw span.
 		ctx = trace.ContextWithSpan(ctx, span)
+		// The request's attributes go on every span it creates, not on the root
+		// alone: the trace backend matches per span, so identity carried only by
+		// the root cannot narrow a search for one agent's model calls.
+		attrs = append(attrs, rc.SpanAttributes()...)
 	}
 	span.SetAttributes(append(attrs, attribute.String(AttrName, display))...)
 	return ctx, span
 }
 
-// bindRoot hands a root entry span to the request lifecycle: the
+// bindRootLifecycle hands a root entry span to the request lifecycle: the
 // RequestContext defers its End until the main flow AND all child flows
-// complete, and stamps the request token totals right before ending. It also
-// stamps the request-wide attributes (sf.request_id, host attrs like sf.agent)
-// on the root span only — child spans do not carry them. Without an rc in ctx
-// (tests, tracing-disabled callers) the caller keeps manual End responsibility.
-func bindRoot(ctx context.Context, span trace.Span) {
+// complete, and stamps the request token totals right before ending. Without
+// an rc in ctx (tests, tracing-disabled callers) the caller keeps manual End
+// responsibility.
+//
+// It decorates nothing. The request's attributes reach this span through
+// createSpan, the same way they reach every other span of the request.
+func bindRootLifecycle(ctx context.Context, span trace.Span) {
 	if rc, ok := requestctx.FromContext(ctx); ok {
-		span.SetAttributes(rc.SpanAttributes()...)
 		rc.BindRootSpan(span, func(s trace.Span) { stampRequestTokens(rc, s) })
 	}
+}
+
+// Span names for the two agent-shaped spans. spanAgentCall is a whole run of
+// an agent's workflow and the stem every entry-qualified variant is built
+// from; spanAgentCallNode is one agent node inside such a run.
+const (
+	spanAgentCall     = "Agent Call"
+	spanAgentCallNode = "AgentCall"
+)
+
+// entrySpanName qualifies the agent-call span with the entry that started the
+// run, so a trace distinguishes a webhook delivery from a sub-workflow call
+// without opening the span. The entry set is fixed by the host, so this stays
+// low-cardinality.
+func entrySpanName(entry string) string {
+	if entry == "" {
+		return spanAgentCall
+	}
+	return spanAgentCall + ": " + entry
 }
 
 // rootDisplay picks the friendly label for a workflow root span: the
@@ -121,7 +145,7 @@ func StartHTTPEntry(ctx context.Context, name, id string) (context.Context, trac
 	ctx, span := createSpan(ctx, "HTTP Entry", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
-	bindRoot(ctx, span)
+	bindRootLifecycle(ctx, span)
 	return ctx, span
 }
 
@@ -170,11 +194,15 @@ func StartResponse(ctx context.Context, id, name string) (context.Context, trace
 
 // StartWorkflowExecute spans a workflow invoked through a trigger (e.g. callworkflow).
 // name is the workflow's friendly display name and id its stable config id.
-func StartWorkflowExecute(ctx context.Context, name, id string) (context.Context, trace.Span) {
-	ctx, span := createSpan(ctx, "Workflow Execute", rootDisplay(name, id),
+//
+// entry names the door the run came through, which the host decides and the
+// engine cannot know, so the span says which kind of call this was rather than
+// naming the machinery that ran it. An empty entry leaves the bare span name.
+func StartWorkflowExecute(ctx context.Context, name, id, entry string) (context.Context, trace.Span) {
+	ctx, span := createSpan(ctx, entrySpanName(entry), rootDisplay(name, id),
 		attribute.String(AttrStepType, "trigger"),
 		attribute.String(AttrWorkflow, id))
-	bindRoot(ctx, span)
+	bindRootLifecycle(ctx, span)
 	return ctx, span
 }
 
@@ -184,7 +212,7 @@ func StartScheduledExecution(ctx context.Context, name, id string) (context.Cont
 	ctx, span := createSpan(ctx, "Scheduled Execution", rootDisplay(name, id),
 		attribute.String(AttrStepType, "scheduled"),
 		attribute.String(AttrWorkflow, id))
-	bindRoot(ctx, span)
+	bindRootLifecycle(ctx, span)
 	return ctx, span
 }
 
@@ -194,22 +222,26 @@ func StartDashboardRun(ctx context.Context, name, id string) (context.Context, t
 	ctx, span := createSpan(ctx, "Dashboard Run", rootDisplay(name, id),
 		attribute.String(AttrStepType, "request"),
 		attribute.String(AttrWorkflow, id))
-	bindRoot(ctx, span)
+	bindRootLifecycle(ctx, span)
 	return ctx, span
 }
 
 // StartAgentInvoke spans a whole agent-action run (the GenAI invoke_agent
-// operation). Its child chat spans are created at the integration boundary.
+// operation). Its child model-call spans are created at the provider boundary.
+//
+// The span is named for what it is rather than for the GenAI operation it
+// reports. gen_ai.operation.name still carries invoke_agent, so a backend that
+// reads the conventions classifies it the same as before.
 func StartAgentInvoke(ctx context.Context, name string) (context.Context, trace.Span) {
 	display := name
 	if display == "" {
-		display = opInvokeAgent
+		display = spanAgentCallNode
 	}
 	attrs := []attribute.KeyValue{attribute.String(AttrGenAIOperation, opInvokeAgent)}
 	if name != "" {
 		attrs = append(attrs, attribute.String(AttrGenAIAgentName, name))
 	}
-	return createSpan(ctx, "invoke_agent", display, attrs...)
+	return createSpan(ctx, spanAgentCallNode, display, attrs...)
 }
 
 // StartAgentTurn spans one iteration of the agent's tool-calling loop: a single
@@ -230,14 +262,27 @@ func StartAgentTurn(ctx context.Context, turn int) (context.Context, trace.Span)
 
 // StartMCPTool spans the invocation of an MCP tool. Carries both the sf.* tool
 // keys and the GenAI execute_tool attributes.
+//
+// The span is a child, which is what an MCP tool called from inside an agent
+// run is. A host whose whole request IS the tool call wants StartMCPEntry: the
+// lifecycle holds one root span per request, so binding this one would replace
+// the entry span and leave it unended, and therefore unexported.
 func StartMCPTool(ctx context.Context, name string) (context.Context, trace.Span) {
-	ctx, span := createSpan(ctx, "MCP Tool", name,
+	return createSpan(ctx, "MCP Tool", name,
 		attribute.String(AttrToolName, name),
 		attribute.String(AttrToolType, "mcp"),
 		attribute.String(AttrGenAIOperation, opExecuteTool),
 		attribute.String(AttrGenAIToolName, name),
 		attribute.String(AttrGenAIToolType, "mcp"))
-	bindRoot(ctx, span)
+}
+
+// StartMCPEntry spans an MCP tool call that is itself the request, as it is for
+// a server whose callers speak MCP and nothing else. The span is the run's
+// root, so the request lifecycle owns its End and stamps the token totals on
+// it.
+func StartMCPEntry(ctx context.Context, name string) (context.Context, trace.Span) {
+	ctx, span := StartMCPTool(ctx, name)
+	bindRootLifecycle(ctx, span)
 	return ctx, span
 }
 

--- a/pkg/tracing/spans_test.go
+++ b/pkg/tracing/spans_test.go
@@ -70,7 +70,7 @@ func TestWorkflowRootSpans(t *testing.T) {
 			return StartHTTPEntry(ctx, "My Workflow", "my-workflow")
 		}},
 		{"trigger", func(ctx context.Context) (context.Context, trace.Span) {
-			return StartWorkflowExecute(ctx, "My Workflow", "my-workflow")
+			return StartWorkflowExecute(ctx, "My Workflow", "my-workflow", "trigger")
 		}},
 		{"scheduled", func(ctx context.Context) (context.Context, trace.Span) {
 			return StartScheduledExecution(ctx, "My Workflow", "my-workflow")
@@ -165,5 +165,69 @@ func TestSpansScrubTrackedSecrets(t *testing.T) {
 				t.Errorf("recorded error not scrubbed: %q", a.Value.AsString())
 			}
 		}
+	}
+}
+
+// TestAgentNodeSpanAttributes covers the two things the agent-node constructor
+// decides: the GenAI operation it reports, which a backend reads to classify
+// the span, and the label an agent with no name of its own falls back to.
+func TestAgentNodeSpanAttributes(t *testing.T) {
+	cases := []struct {
+		name        string
+		agent       string
+		wantDisplay string
+	}{
+		{"named agent labels the span", "Responder", "Responder"},
+		{"unnamed agent falls back to the span name", "", "AgentCall"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sr := tracetest.NewSpanRecorder()
+			otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+			tracer = otel.Tracer("servflow-test")
+
+			_, span := StartAgentInvoke(context.Background(), tc.agent)
+			span.End()
+
+			attrs := attrMap(sr.Ended()[0].Attributes())
+			if got := attrs[AttrGenAIOperation]; got != opInvokeAgent {
+				t.Errorf("%s = %v, want %q", AttrGenAIOperation, got, opInvokeAgent)
+			}
+			if got := attrs[AttrName]; got != tc.wantDisplay {
+				t.Errorf("%s = %v, want %q", AttrName, got, tc.wantDisplay)
+			}
+		})
+	}
+}
+
+// TestRequestTotalsLandOnTheEntrySpan holds the rule that one request has one
+// root span: the entry span is the span the lifecycle ends and stamps the token
+// totals on, however many tool calls run underneath it. A tool constructor that
+// binds itself breaks this by replacing the entry span, which then never ends
+// and never exports.
+func TestRequestTotalsLandOnTheEntrySpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	tracer = otel.Tracer("servflow-test")
+
+	ctx, rc := requestctx.Start(context.Background(), requestctx.Options{ID: "req-mcp"})
+	ctx, _ = StartHTTPEntry(ctx, "My Workflow", "wf-id")
+
+	// A tool call one level down, ended by its own caller.
+	_, toolSpan := StartMCPTool(ctx, "search")
+	rc.AddTokenUsage(10, 5)
+	toolSpan.End()
+
+	// The response is written; the lifecycle ends the span it owns.
+	rc.Done()
+
+	root := endedByName(t, sr.Ended(), "HTTP Entry")
+	if got := attrMap(root.Attributes())[AttrUsageTotal]; got != int64(15) {
+		t.Errorf("%s = %v, want 15 on the entry span", AttrUsageTotal, got)
+	}
+
+	tool := endedByName(t, sr.Ended(), "MCP Tool")
+	if _, ok := attrMap(tool.Attributes())[AttrUsageTotal]; ok {
+		t.Errorf("%s must not land on a tool span", AttrUsageTotal)
 	}
 }


### PR DESCRIPTION
Part of a tracing cleanup driven from the pro side. The plan lives in
servflowai at `docs/tracing-cleanup-plan.md`; this is its engine half.

## What changes

**Request attributes reach every span.** `createSpan` stamps
`rc.SpanAttributes()`, rather than `bindRoot` stamping them on the root
alone. The trace backend matches per span, so identity only the root carried
could not narrow a search for one agent's model calls. This is also what the
`Options.SpanAttributes` doc comment has always described. `bindRoot` keeps
only the lifecycle handoff and is renamed `bindRootLifecycle`.

**Spans are named for the work, not the machinery.**

| Before | After |
| --- | --- |
| `Workflow Execute` | `Agent Call: <entry>` |
| `invoke_agent` | `AgentCall` |
| `chat` | `LLM Call` |

`StartWorkflowExecute` takes an `entry` parameter, because which door a run
came through is the host's knowledge, not the engine's. Every
`gen_ai.operation.name` value is unchanged, so a backend reading the GenAI
conventions classifies these spans as it did before.

**`StartMCPTool` no longer binds a root span.** Binding is correct for the
engine's MCP server, where the tool call is the whole request, and wrong for
a host that calls MCP tools inside an agent run. The lifecycle holds one
root per request, so a second bind replaced the entry span, which then never
ended and therefore never exported — the trace lost its root, and the tool
span ended twice. `StartMCPEntry` binds; `mcp_handler.go` uses it.

## Not in this PR

Capping what a span attribute can carry. `sf.result` and `response_body`
still export in full, and a host's own payload attribute now travels to
every span. That is its own change.

## Breaking change for hosts

`StartWorkflowExecute` gains a fourth parameter. Pass the entry name, or `""`
for the unqualified span name.

## Tests

`go test ./...` passes. New coverage for every span name, for both GenAI
operation values surviving their rename, and a regression test proving an
MCP tool call no longer takes the request's root span. The lifecycle
integration test now asserts that child spans do carry the request
attributes, which inverts what it asserted before.